### PR TITLE
Add meta-tags API

### DIFF
--- a/app/controllers/maps/metadata_controller.rb
+++ b/app/controllers/maps/metadata_controller.rb
@@ -1,0 +1,7 @@
+module Maps
+  class MetadataController < ApplicationController
+    def show
+      @map = Map.find_by!(id: params[:map_id], private: false)
+    end
+  end
+end

--- a/app/controllers/reviews/metadata_controller.rb
+++ b/app/controllers/reviews/metadata_controller.rb
@@ -1,0 +1,7 @@
+module Reviews
+  class MetadataController < ApplicationController
+    def show
+      @review = Review.left_outer_joins(:map).find_by!(maps: { private: false }, reviews: { id: params[:review_id] })
+    end
+  end
+end

--- a/app/views/maps/metadata/show.jbuilder
+++ b/app/views/maps/metadata/show.jbuilder
@@ -1,0 +1,3 @@
+json.title @map.name
+json.description @map.description
+json.image_url ENV['SUBSTITUTE_URL']

--- a/app/views/reviews/metadata/show.jbuilder
+++ b/app/views/reviews/metadata/show.jbuilder
@@ -1,0 +1,3 @@
+json.title "#{@review.spot.name} - #{@review.map.name}"
+json.description @review.comment
+json.image_url @review.image_url.present? ? @review.image_url : ENV['SUBSTITUTE_URL']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,12 @@ Rails.application.routes.draw do
       resources :spots, only: [:index, :show]
       resources :collaborators, only: [:index]
       resource :follow, only: [:create, :destroy]
+      resource :metadata, only: [:show]
     end
   end
-  resources :reviews, only: [:update, :destroy]
+  resources :reviews, only: [:update, :destroy] do
+    scope module: :reviews do
+      resource :metadata, only: [:show]
+    end
+  end
 end

--- a/test/controllers/maps/metadata_controller_test.rb
+++ b/test/controllers/maps/metadata_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Maps::MetadataControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/reviews/metadata_controller_test.rb
+++ b/test/controllers/reviews/metadata_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Reviews::MetadataControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
bot アクセス用に、 map および review のメタ情報を返す API を追加。
map が private 設定の場合は 404 を返す。