### PR TITLE
Firebase cloud messaging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
+WEB_ENDPOINT=http://localhost:3000
+
 FIREBACE_PROJECT_ID=my-project
 
 AWS_REGION=ap-northeast-1
@@ -11,3 +13,7 @@ SUBSTITUTE_URL=https://s3-ap-northeast-1.amazonaws.com/qoodish/substitute.png
 GITHUB_API_ENDPOINT=https://api.github.com
 
 GOOGLE_API_KEY_SERVER=apikey
+
+FCM_SERVER_KEY=serverkey
+GOOGLE_IID_ENDPOINT=https://iid.googleapis.com
+FCM_ENDPOINT=https://fcm.googleapis.com

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -1,0 +1,9 @@
+class DevicesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    @current_user.devices.find_or_create_by!(
+      registration_token: params[:registration_token]
+    )
+  end
+end

--- a/app/controllers/maps/follows_controller.rb
+++ b/app/controllers/maps/follows_controller.rb
@@ -3,17 +3,24 @@ module Maps
     before_action :authenticate_user!
 
     def create
-      map = Map.includes(:user, :reviews).find_by!(id: params[:map_id])
-      raise Exceptions::NotFound unless current_user.referenceable?(map)
-      current_user.follow(map)
-      @map = map.reload
+      ActiveRecord::Base.transaction do
+        map = Map.includes(:user, :reviews).find_by!(id: params[:map_id])
+        raise Exceptions::NotFound unless current_user.referenceable?(map)
+        current_user.follow(map)
+        @map = map.reload
+        current_user.subscribe_topic("map_#{@map.id}")
+        current_user.send_message_to_topic("map_#{@map.id}", "#{current_user.name} joined #{@map.name}.", "maps/#{@map.id}")
+      end
     end
 
     def destroy
-      map = Map.includes(:user, :reviews).find_by!(id: params[:map_id])
-      raise Exceptions::MapOwnerCannotRemoved if current_user.map_owner?(map)
-      current_user.stop_following(map)
-      @map = map.reload
+      ActiveRecord::Base.transaction do
+        map = Map.includes(:user, :reviews).find_by!(id: params[:map_id])
+        raise Exceptions::MapOwnerCannotRemoved if current_user.map_owner?(map)
+        current_user.stop_following(map)
+        @map = map.reload
+        current_user.unsubscribe_topic("map_#{@map.id}")
+      end
     end
   end
 end

--- a/app/controllers/maps/reviews_controller.rb
+++ b/app/controllers/maps/reviews_controller.rb
@@ -15,14 +15,18 @@ module Maps
     end
 
     def create
-      map = Map.find_by!(id: params[:map_id])
-      raise Exceptions::NotFound unless current_user.postable?(map)
-      @review = current_user.reviews.create!(
-        map: map,
-        place_id_val: params[:place_id],
-        comment: params[:comment],
-        image_url: params[:image_url]
-      )
+      ActiveRecord::Base.transaction do
+        map = Map.find_by!(id: params[:map_id])
+        raise Exceptions::NotFound unless current_user.postable?(map)
+        @review = current_user.reviews.create!(
+          map: map,
+          place_id_val: params[:place_id],
+          comment: params[:comment],
+          image_url: params[:image_url]
+        )
+        message = "#{current_user.name} posted a report on #{@review.spot.name} on #{map.name}."
+        current_user.send_message_to_topic("map_#{map.id}", message, "maps/#{map.id}/reports/#{@review.id}")
+      end
     end
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -27,6 +27,7 @@ class MapsController < ApplicationController
         base_name: params[:base_name]
       )
       current_user.follow(@map)
+      current_user.subscribe_topic("map_#{@map.id}")
     end
   end
 
@@ -37,7 +38,9 @@ class MapsController < ApplicationController
 
   def destroy
     ActiveRecord::Base.transaction do
-      current_user.maps.find_by!(id: params[:id]).destroy!
+      map = current_user.maps.find_by!(id: params[:id])
+      current_user.unsubscribe_topic("map_#{map.id}")
+      map.destroy!
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,7 @@ class UsersController < ApplicationController
 
   def destroy
     ActiveRecord::Base.transaction do
+      current_user.unfollow_all_maps
       current_user.destroy!
     end
   end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: devices
+#
+#  id                 :integer          not null, primary key
+#  user_id            :integer          not null
+#  registration_token :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+# Indexes
+#
+#  index_devices_on_registration_token              (registration_token)
+#  index_devices_on_user_id                         (user_id)
+#  index_devices_on_user_id_and_registration_token  (user_id,registration_token) UNIQUE
+#
+
+class Device < ApplicationRecord
+  belongs_to :user
+
+  validates :user_id,
+            presence: true
+  validates :registration_token,
+            presence: {
+              strict: Exceptions::RegistrationTokenNotSpecified
+            },
+            uniqueness: {
+              scope: :user_id,
+              strict: Exceptions::DuplicateRegistrationToken
+            }
+end

--- a/app/models/exceptions.rb
+++ b/app/models/exceptions.rb
@@ -127,8 +127,20 @@ module Exceptions
   end
 
   class MapOwnerCannotRemoved < BadRequest
-    def initialize(message = I18n.t('api_response.messages.map_owner_cannot_removed'))
+    def initialize(*)
       super(I18n.t('messages.api.map_owner_cannot_removed'))
+    end
+  end
+
+  class RegistrationTokenNotSpecified < BadRequest
+    def initialize(*)
+      super(I18n.t('messages.api.registration_token_is_required'))
+    end
+  end
+
+  class DuplicateRegistrationToken < BadRequest
+    def initialize(*)
+      super(I18n.t('messages.api.registration_token_is_duplicated'))
     end
   end
 end

--- a/app/models/fcm.rb
+++ b/app/models/fcm.rb
@@ -1,0 +1,31 @@
+class Fcm < ApiClientBase
+  def send_message_to_topic(topic_name, body, request_path)
+    headers = {
+      Authorization: "key=#{ENV['FCM_SERVER_KEY']}",
+      'Content-Type' => 'application/json'
+    }
+    params = {
+      to: "/topics/#{topic_name}",
+      notification: {
+        title: 'Qoodish',
+        body: body,
+        icon: ENV['SUBSTITUTE_URL'],
+        click_action: "#{ENV['WEB_ENDPOINT']}/#{request_path}"
+      }
+    }
+    response = request('/fcm/send', headers, params.to_json, :post)
+
+    case response.status
+    when 200
+      json = JSON.parse(response.body)
+    when 401
+      raise Exceptions::Unauthorized
+    when 404
+      raise Exceptions::NotFound
+    else
+      raise Exceptions::InternalServerError
+    end
+
+    json
+  end
+end

--- a/app/models/google_iid.rb
+++ b/app/models/google_iid.rb
@@ -1,0 +1,45 @@
+class GoogleIid < ApiClientBase
+  def subscribe_topic(registration_token, topic_name)
+    headers = {
+      Authorization: "key=#{ENV['FCM_SERVER_KEY']}",
+      'Content-Type' => 'application/json'
+    }
+    response = request("/iid/v1/#{registration_token}/rel/topics/#{topic_name}", headers, {}, :post)
+    Rails.logger.debug(response)
+
+    case response.status
+    when 200
+      json = JSON.parse(response.body)
+    when 401
+      raise Exceptions::Unauthorized
+    when 404
+      raise Exceptions::NotFound
+    else
+      raise Exceptions::InternalServerError
+    end
+
+    json
+  end
+
+  def unsubscribe_topic(registration_token, topic_name)
+    headers = {
+      Authorization: "key=#{ENV['FCM_SERVER_KEY']}",
+      'Content-Type' => 'application/json'
+    }
+    response = request("/iid/v1/#{registration_token}/rel/topics/#{topic_name}", headers, {}, :delete)
+    Rails.logger.debug(response)
+
+    case response.status
+    when 200
+      json = JSON.parse(response.body)
+    when 401
+      raise Exceptions::Unauthorized
+    when 404
+      raise Exceptions::NotFound
+    else
+      raise Exceptions::InternalServerError
+    end
+
+    json
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,3 +54,6 @@ en:
       invalid_uri: Invalid URI.
 
       map_owner_cannot_removed: Map owner cannot be removed.
+
+      registration_token_is_required: Registration token is required.
+      registration_token_is_duplicated: Registration token is duplicated.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :users, only: [:create, :destroy]
+  resources :devices, only: [:create]
   resources :maps do
     scope module: :maps do
       resources :reviews, only: [:index, :show, :create]

--- a/db/migrate/20170901041457_create_devices.rb
+++ b/db/migrate/20170901041457_create_devices.rb
@@ -1,0 +1,12 @@
+class CreateDevices < ActiveRecord::Migration[5.1]
+  def change
+    create_table :devices do |t|
+      t.references :user, index: true, foreign_key: true, null: false
+      t.string :registration_token, null: false
+
+      t.timestamps
+    end
+    add_index :devices, :registration_token
+    add_index :devices, [:user_id, :registration_token], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170826055656) do
+ActiveRecord::Schema.define(version: 20170901041457) do
+
+  create_table "devices", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "registration_token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["registration_token"], name: "index_devices_on_registration_token"
+    t.index ["user_id", "registration_token"], name: "index_devices_on_user_id_and_registration_token", unique: true
+    t.index ["user_id"], name: "index_devices_on_user_id"
+  end
 
   create_table "follows", force: :cascade do |t|
     t.string "followable_type", null: false

--- a/test/controllers/devices_controller_test.rb
+++ b/test/controllers/devices_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DevicesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/devices.yml
+++ b/test/fixtures/devices.yml
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: devices
+#
+#  id                 :integer          not null, primary key
+#  user_id            :integer          not null
+#  registration_token :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+# Indexes
+#
+#  index_devices_on_registration_token              (registration_token)
+#  index_devices_on_user_id                         (user_id)
+#  index_devices_on_user_id_and_registration_token  (user_id,registration_token) UNIQUE
+#
+
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  registration_token: MyString
+
+two:
+  user_id: 1
+  registration_token: MyString

--- a/test/models/device_test.rb
+++ b/test/models/device_test.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: devices
+#
+#  id                 :integer          not null, primary key
+#  user_id            :integer          not null
+#  registration_token :string           not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
+# Indexes
+#
+#  index_devices_on_registration_token              (registration_token)
+#  index_devices_on_user_id                         (user_id)
+#  index_devices_on_user_id_and_registration_token  (user_id,registration_token) UNIQUE
+#
+
+require 'test_helper'
+
+class DeviceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
map に誰かが join したり review を投稿した際に、map の参加者に対してプッシュ通知を飛ばすようにした。

* ユーザーがアプリを起動した際に、ユーザーが使用しているクライアント (PC, mobile etc.) ごとの registration token を取得して API に送信 & DB に保存。
* map に join した際に map ごとの topic 購読処理を行う (registration token 使用)。
* map 上に参加者の誰かがリソースを作成したり誰かが join したら、map に対応する topic に対して通知を飛ばす。

https://firebase.google.com/docs/cloud-messaging/js/client?hl=ja
http://blog.soushi.me/entry/2017/05/23/100711
https://firebase.google.com/docs/cloud-messaging/http-server-ref?hl=ja#header
