### PR TITLE
Bulk add/remove request to subscribe/unsubscribe topic

### DIFF
--- a/app/models/google_iid.rb
+++ b/app/models/google_iid.rb
@@ -5,7 +5,6 @@ class GoogleIid < ApiClientBase
       'Content-Type' => 'application/json'
     }
     response = request("/iid/v1/#{registration_token}/rel/topics/#{topic_name}", headers, {}, :post)
-    Rails.logger.debug(response)
 
     case response.status
     when 200
@@ -27,7 +26,56 @@ class GoogleIid < ApiClientBase
       'Content-Type' => 'application/json'
     }
     response = request("/iid/v1/#{registration_token}/rel/topics/#{topic_name}", headers, {}, :delete)
-    Rails.logger.debug(response)
+
+    case response.status
+    when 200
+      json = JSON.parse(response.body)
+    when 401
+      raise Exceptions::Unauthorized
+    when 404
+      raise Exceptions::NotFound
+    else
+      raise Exceptions::InternalServerError
+    end
+
+    json
+  end
+
+  def bulk_subscribe_topic(registration_tokens, topic_name)
+    headers = {
+      Authorization: "key=#{ENV['FCM_SERVER_KEY']}",
+      'Content-Type' => 'application/json'
+    }
+    params = {
+      to: "/topics/#{topic_name}",
+      registration_tokens: registration_tokens
+    }
+    response = request('/iid/v1:batchAdd', headers, params.to_json, :post)
+
+    case response.status
+    when 200
+      json = JSON.parse(response.body)
+    when 401
+      raise Exceptions::Unauthorized
+    when 404
+      raise Exceptions::NotFound
+    else
+      raise Exceptions::InternalServerError
+    end
+
+    json
+  end
+
+  def bulk_unsubscribe_topic(registration_tokens, topic_name)
+    headers = {
+      Authorization: "key=#{ENV['FCM_SERVER_KEY']}",
+      'Content-Type' => 'application/json'
+    }
+    params = {
+      to: "/topics/#{topic_name}",
+      registration_tokens: registration_tokens
+    }
+    response = request('/iid/v1:batchRemove', headers, params.to_json, :post)
 
     case response.status
     when 200

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,23 +115,13 @@ class User < ApplicationRecord
   end
 
   def subscribe_topic(topic)
-    devices.each do |device|
-      begin
-        iid_client.subscribe_topic(device.registration_token, topic)
-      rescue Exceptions::NotFound
-        device.destroy!
-      end
-    end
+    registration_tokens = devices.pluck(:registration_token)
+    iid_client.bulk_subscribe_topic(registration_tokens, topic)
   end
 
   def unsubscribe_topic(topic)
-    devices.each do |device|
-      begin
-        iid_client.unsubscribe_topic(device.registration_token, topic)
-      rescue Exceptions::NotFound
-        device.destroy!
-      end
-    end
+    registration_tokens = devices.pluck(:registration_token)
+    iid_client.bulk_unsubscribe_topic(registration_tokens, topic)
   end
 
   def send_message_to_topic(topic, message, request_path)


### PR DESCRIPTION
一度のリクエストで複数の Instance ID を topic に登録できるように修正。
https://developers.google.com/instance-id/reference/server#manage_relationship_maps_for_multiple_app_instances
https://firebase.google.com/docs/cloud-messaging/admin/manage-topic-subscriptions
https://firebase.google.com/docs/cloud-messaging/admin/errors

複数の topic を一発で購読するような API は見つからなかった。
そのため IID 登録時点でフォローしているマップの数だけリクエストを投げることになってしまっている。