### PR TITLE
Stop following when delete map

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -40,6 +40,7 @@ class MapsController < ApplicationController
     ActiveRecord::Base.transaction do
       map = current_user.maps.find_by!(id: params[:id])
       current_user.unsubscribe_topic("map_#{map.id}")
+      current_user.stop_following(map)
       map.destroy!
     end
   end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -21,7 +21,7 @@
 
 class Map < ApplicationRecord
   belongs_to :user
-  has_many :reviews
+  has_many :reviews, dependent: :destroy
 
   attr_accessor :base_lat, :base_lng
 


### PR DESCRIPTION
マップ削除の際に `InvalidForeignKey` エラーになっていたので、マップ下のリソースも同時に全て削除するように修正。
少し危険な仕様なので、論理削除等は別途検討していく。