### PR TITLE
Not to send message if registration token is empty

### DIFF
--- a/app/controllers/maps/reviews_controller.rb
+++ b/app/controllers/maps/reviews_controller.rb
@@ -29,7 +29,7 @@ module Maps
           comment: params[:comment],
           image_url: params[:image_url]
         )
-        message = "#{current_user.name} posted a report on #{@review.spot.name} on #{map.name}."
+        message = "#{current_user.name} posted a report about #{@review.spot.name} on #{map.name}."
         current_user.send_message_to_topic("map_#{map.id}", message, "maps/#{map.id}/reports/#{@review.id}")
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,6 +132,7 @@ class User < ApplicationRecord
 
   def send_message_to_user(recipient, message, request_path)
     registration_tokens = recipient.devices.pluck(:registration_token)
+    return if registration_tokens.blank?
     fcm_client.send_message_to_devices(registration_tokens, message, request_path)
   end
 


### PR DESCRIPTION
登録トークンが空の場合はメッセージを送信しないように修正。