### PR TITLE
Remove /api scope from routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,34 +1,32 @@
 Rails.application.routes.draw do
-  scope :api do
-    resources :users, only: [:show, :create, :destroy] do
-      scope module: :users do
-        resources :maps, only: [:index]
-      end
+  resources :users, only: [:show, :create, :destroy] do
+    scope module: :users do
+      resources :maps, only: [:index]
     end
-    resources :devices, only: [:create, :destroy]
-    resources :maps do
-      scope module: :maps do
-        resources :reviews, only: [:index, :show, :create]
-        resources :spots, only: [:index, :show]
-        resources :collaborators, only: [:index]
-        resource :follow, only: [:create, :destroy]
-        resource :metadata, only: [:show]
-      end
-    end
-    resources :reviews, only: [:index, :update, :destroy] do
-      scope module: :reviews do
-        resource :metadata, only: [:show]
-        resource :like, only: [:create, :destroy]
-        resources :likes, only: [:index]
-      end
-    end
-    resources :inappropriate_contents, only: [:create]
-    resources :places, only: [:index]
-    resources :spots, only: [:show] do
-      scope module: :spots do
-        resources :reviews, only: [:index]
-      end
-    end
-    resources :notifications, only: [:index, :update]
   end
+  resources :devices, only: [:create, :destroy]
+  resources :maps do
+    scope module: :maps do
+      resources :reviews, only: [:index, :show, :create]
+      resources :spots, only: [:index, :show]
+      resources :collaborators, only: [:index]
+      resource :follow, only: [:create, :destroy]
+      resource :metadata, only: [:show]
+    end
+  end
+  resources :reviews, only: [:index, :update, :destroy] do
+    scope module: :reviews do
+      resource :metadata, only: [:show]
+      resource :like, only: [:create, :destroy]
+      resources :likes, only: [:index]
+    end
+  end
+  resources :inappropriate_contents, only: [:create]
+  resources :places, only: [:index]
+  resources :spots, only: [:show] do
+    scope module: :spots do
+      resources :reviews, only: [:index]
+    end
+  end
+  resources :notifications, only: [:index, :update]
 end


### PR DESCRIPTION
Web アプリを firebase hosting 上に移動したことに伴い、API のエンドポイントをパスで分ける必要がなくなりました。 