### PR TITLE
Add place validation

### DIFF
--- a/app/models/exceptions.rb
+++ b/app/models/exceptions.rb
@@ -102,6 +102,12 @@ module Exceptions
     end
   end
 
+  class PlaceNotFound < BadRequest
+    def initialize(*)
+      super(I18n.t('messages.api.place_not_found'))
+    end
+  end
+
   class CommentNotSpecified < BadRequest
     def initialize(*)
       super(I18n.t('messages.api.comment_required'))

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -86,7 +86,7 @@ class Map < ApplicationRecord
   private
 
   def remove_carriage_return
-    description.gsub!(/\r/, '') if name
+    name.gsub!(/\r/, '') if name
     description.gsub!(/\r/, '') if description
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -62,6 +62,7 @@ class Review < ApplicationRecord
               with: /\A#{URI::regexp(%w(http https))}\z/,
               scrict: Exceptions::InvalidUri
             }
+  validate :validate_spot
 
   FEED_PER_PAGE = 20
 
@@ -91,5 +92,9 @@ class Review < ApplicationRecord
   def remove_carriage_return
     return unless comment
     comment.gsub!(/\r/, '')
+  end
+
+  def validate_spot
+    raise Exceptions::PlaceNotFound if spot.name.blank?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,8 +49,10 @@ en:
 
       duplicate_reviews: You can not post about the same spot.
       place_id_not_specified: Place ID has not been specified.
+      place_not_found: Place not found.
+
       comment_required: Comment is required.
-      comment_exceeded: 'Comment is too long (Max: 200)'.
+      comment_exceeded: 'Comment is too long. (Max: 200)'
       invalid_uri: Invalid URI.
 
       map_owner_cannot_removed: Map owner cannot be removed.


### PR DESCRIPTION
Review 作成時にターゲットとなるスポットが Google Places API 上に存在しなかった場合はエラーとなるように修正しました。