### PR TITLE
Remove dependent destroy

### DIFF
--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -25,7 +25,7 @@
 
 class Map < ApplicationRecord
   belongs_to :user
-  has_many :reviews, dependent: :destroy
+  has_many :reviews
   has_many :notifications, as: :notifiable
   has_many :invites, as: :invitable, dependent: :destroy
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -94,7 +94,7 @@ class Review < ApplicationRecord
   }
 
   scope :recent, lambda {
-    includes(:user, :map).where(maps: { private: false }).order(created_at: :desc).limit(4)
+    includes(:user, :map).where(maps: { private: false }).order(created_at: :desc).limit(8)
   }
 
   def spot


### PR DESCRIPTION
* マップを削除したときに、マップに紐づくレポートが削除されないようにしました。
* 最新のレポートの取得件数を増やしました。