### PR TITLE
Revert dependent destroy

### DIFF
--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -25,7 +25,7 @@
 
 class Map < ApplicationRecord
   belongs_to :user
-  has_many :reviews
+  has_many :reviews, dependent: :destroy
   has_many :notifications, as: :notifiable
   has_many :invites, as: :invitable, dependent: :destroy
 


### PR DESCRIPTION
Google+ のコミュニティなどを参考に、マップ削除時に全てのレポートが削除される方式に戻しました。