### PR TITLE
Remove redis-namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'googleauth'
 gem 'http_accept_language'
 gem 'jwt'
 gem 'mysql2', '~> 0.4.10'
-gem 'redis-namespace'
 gem 'redis-objects'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,8 +175,6 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.1.0)
-    redis-namespace (1.6.0)
-      redis (>= 3.0.4)
     redis-objects (1.4.3)
       redis (~> 4.0)
     ruby_dep (1.5.0)
@@ -228,7 +226,6 @@ DEPENDENCIES
   puma (~> 3.7)
   rack-cors
   rails (~> 6.0.0.beta1)
-  redis-namespace
   redis-objects
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,2 @@
-namespace = [Rails.application.class.parent_name, Rails.env].join ':'
-Redis.current = Redis::Namespace.new(namespace, redis: Redis.new(host: ENV['REDIS_HOST']))
+Redis.current = Redis.new(host: ENV['REDIS_HOST'])
 Rails.logger.info("Currently connected to Redis: #{Redis.current.inspect}")


### PR DESCRIPTION
以下の理由により redis-namespace を廃止しました。
* 現状の Redis の用途が Google Places API のプレイス詳細リクエストのキャッシュのみ
* 他に用途が増えるとして、namespace ではなく Redis の DB やコンテナ単位で分けるべき