### PR TITLE
Fix Create Invite API

### DIFF
--- a/app/controllers/maps/invites_controller.rb
+++ b/app/controllers/maps/invites_controller.rb
@@ -19,18 +19,6 @@ module Maps
           recipient: recipient,
           key: 'invited'
         )
-        message = "#{current_user.name} invited you to #{map.name}."
-        data = {
-          notification_type: 'invite',
-          invite_id: invite.id
-        }
-        current_user.send_message_to_topic(
-          "user_#{recipient.id}",
-          message,
-          'invites',
-          nil,
-          data
-        )
       end
     end
   end


### PR DESCRIPTION
Invites API のプッシュ通知送信処理が重複していた (消し忘れ) ので削除しました。