### PR TITLE
Fix unfollowing maps query

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -9,6 +9,7 @@ class ReviewsController < ApplicationController
           .public_open
           .limit(8)
           .includes(:user, :map, :comments)
+          .order(created_at: :desc)
       elsif params[:next_timestamp]
         Review
           .following_by(current_user)

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -63,12 +63,14 @@ class Map < ApplicationRecord
 
   scope :following_by, lambda { |user|
     joins(:follows)
+      .group('maps.id')
       .where(follows: { follower: user })
   }
 
   scope :unfollowing_by, lambda { |user|
     joins(:follows)
-      .where.not(follows: { follower: user })
+      .group('maps.id')
+      .having('count(follows.follower_id = ? or null) < 1', user.id)
   }
 
   scope :active, lambda {


### PR DESCRIPTION
フォローしていないマップを抽出するロジックが間違っていたので修正しました。
また、最近作成されたレポート一覧のソートが古い順になっていたので修正しました。