### PR TITLE
Fix map spot reviews

### DIFF
--- a/app/controllers/maps/reviews_controller.rb
+++ b/app/controllers/maps/reviews_controller.rb
@@ -9,7 +9,7 @@ module Maps
           current_user
             .referenceable_reviews
             .includes(:map, :user, :comments)
-            .where(place_id_val: params[:place_id])
+            .where(place_id_val: params[:place_id], map_id: params[:map_id])
         else
           current_user
             .referenceable_reviews

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -38,7 +38,7 @@ class Review < ApplicationRecord
             }
   validate :validate_spot
 
-  FEED_PER_PAGE = 10
+  FEED_PER_PAGE = 12
 
   scope :public_open, lambda {
     joins(:map)


### PR DESCRIPTION
* マップ & プレイス下のレポートの scope が間違っていたので修正しました。
* フィード上で一度に取得するレビューの件数を 12 件に変更しました。