### PR TITLE
Fix search maps scope

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -7,7 +7,7 @@ class MapsController < ApplicationController
       if params[:input].present?
         current_user
           .referenceable_maps
-          .where(Map.search_by_words(params[:input].strip.split(/[[:blank:]]+/)))
+          .search_by_words(params[:input].strip.split(/[[:blank:]]+/))
           .limit(20)
           .includes(:user, :reviews)
           .order(created_at: :desc)


### PR DESCRIPTION
マップ検索 API の scope の適用の仕方が誤っていたので修正しました。