### PR TITLE
Fix Rails log level

### DIFF
--- a/app/models/pub_sub.rb
+++ b/app/models/pub_sub.rb
@@ -45,7 +45,6 @@ class PubSub
 end
 
 module SubscriberLogger
-  Rails.logger.level = Logger::INFO
   LOGGER = Rails.logger
 
   def logger

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV['RAILS_LOG_LEVEL'] ? ENV['RAILS_LOG_LEVEL'].to_sym : :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       - DB_HOST=db
       - DB_USER=root
       - DB_PASSWORD=password
+      - RAILS_LOG_LEVEL=debug
     command: >
       /bin/bash -c "rm -f /qoodish/tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
@@ -40,6 +41,7 @@ services:
       - DB_HOST=db
       - DB_USER=root
       - DB_PASSWORD=password
+      - RAILS_LOG_LEVEL=info
     command: >
       bundle exec rails subscriber:run --trace
     depends_on:


### PR DESCRIPTION
Subscriber のログレベル設定に API が引き摺られてしまっていたので、コンテナごとに環境変数でログレベルを設定するように修正しました。