### PR TITLE
Fetch popular reviews for anonymous user

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -15,6 +15,11 @@ class ReviewsController < ApplicationController
           .following_by(current_user)
           .feed_before(params[:next_timestamp])
           .includes(:user, :map, :comments)
+      elsif current_user.is_anonymous
+        Review
+          .public_open
+          .includes(:user, :map)
+          .popular
       else
         Review
           .following_by(current_user)

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -65,6 +65,13 @@ class Review < ApplicationRecord
       .limit(FEED_PER_PAGE)
   }
 
+  scope :popular, lambda {
+    joins(:votes)
+      .group('reviews.id')
+      .order('count(votes.id) desc')
+      .limit(10)
+  }
+
   def spot
     @spot ||= Spot.new(place_id_val, thumbnail_url)
   end


### PR DESCRIPTION
ユーザーフィード取得 API において、非ログインユーザーからのリクエストだった場合は人気のレポート (いいねが多いレポート) の一覧を返すようにしました。