### PR TITLE
Comment colums on review to text

### DIFF
--- a/db/migrate/20190714100814_change_comment_string_to_text.rb
+++ b/db/migrate/20190714100814_change_comment_string_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeCommentStringToText < ActiveRecord::Migration[6.0]
+  def change
+    change_column :reviews, :comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_17_041543) do
+ActiveRecord::Schema.define(version: 2019_07_14_100814) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "commentable_type", null: false
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(version: 2019_03_17_041543) do
     t.bigint "user_id", null: false
     t.bigint "map_id", null: false
     t.string "place_id_val", null: false
-    t.string "comment", null: false
+    t.text "comment", null: false
     t.string "image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
レポートの文字数制限を 500 字にしたことに伴い、comment カラムを string 型から text 型に変更しました。