### PR TITLE
Fix popular reviews API

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -21,7 +21,7 @@ class ReviewsController < ApplicationController
         Rails.cache.fetch('popular_reviews', expires_in: 5.minutes) do
           Review
             .public_open
-            .with_deps
+            .includes(:map, :user)
             .popular
         end
       else


### PR DESCRIPTION
review の `popular` scope のロジック上 include できないテーブルを include して 500 エラーとなっていたので修正しました