### PR TITLE
Fixed an issue where place was not refreshed if the cache did not exist

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -9,7 +9,7 @@ class Place < ApplicationRecord
             uniqueness: true
 
   after_create :load_cache
-  after_find :load_cache
+  after_initialize :load_cache
 
   scope :popular, lambda {
     joins(:reviews)


### PR DESCRIPTION
Use `after_initialize` callback instead of `after_find` .