### PR TITLE
Handle invalid locales in RequestContextMiddleware

### DIFF
--- a/lib/request_context_middleware.rb
+++ b/lib/request_context_middleware.rb
@@ -19,7 +19,14 @@ class RequestContextMiddleware
 
   def calculate_locale(request)
     header = request.env['HTTP_ACCEPT_LANGUAGE']
-    locale = header&.scan(/^[a-z]{2}/)&.first || I18n.default_locale
+    extracted_locale = header&.scan(/^[a-z]{2}/)&.first
+
+    locale = if I18n.available_locales.map(&:to_s).include?(extracted_locale)
+               extracted_locale
+             else
+               I18n.default_locale
+             end
+
     I18n.locale = locale
     locale
   end


### PR DESCRIPTION
This pull request updates the locale extraction logic in the `calculate_locale` method to ensure that only supported locales are set. Now, the locale from the `HTTP_ACCEPT_LANGUAGE` header is checked against the list of available locales before being used, which helps prevent setting an unsupported locale.

Locale handling improvements:

* Updated the `calculate_locale` method in `lib/request_context_middleware.rb` to verify that the extracted locale is included in `I18n.available_locales` before setting it, defaulting to `I18n.default_locale` otherwise.