### PR TITLE
feat: enable CPU throttling for Cloud Run services

### DIFF
--- a/run/dev/api/base.yaml
+++ b/run/dev/api/base.yaml
@@ -11,7 +11,6 @@ spec:
   template:
     metadata:
       annotations:
-        run.googleapis.com/cpu-throttling: "false"
         run.googleapis.com/network-interfaces: '[{"network":"default","subnetwork":"default"}]'
         run.googleapis.com/vpc-access-egress: private-ranges-only
         run.googleapis.com/execution-environment: gen2

--- a/run/prod/api/base.yaml
+++ b/run/prod/api/base.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     metadata:
       annotations:
-        run.googleapis.com/cpu-throttling: "false"
         run.googleapis.com/network-interfaces: '[{"network":"default","subnetwork":"default"}]'
         run.googleapis.com/vpc-access-egress: private-ranges-only
         run.googleapis.com/execution-environment: gen2


### PR DESCRIPTION
This pull request removes the `run.googleapis.com/cpu-throttling: "false"` annotation from both the development and production API deployment configurations. This change simplifies the deployment settings and may allow the platform to manage CPU throttling according to default behavior.

Configuration cleanup:

* Removed the `run.googleapis.com/cpu-throttling: "false"` annotation from `run/dev/api/base.yaml` to rely on default CPU throttling settings.
* Removed the `run.googleapis.com/cpu-throttling: "false"` annotation from `run/prod/api/base.yaml` for consistency with development and platform defaults.