### PR TITLE
fix: use GitHub App token to trigger workflows

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,7 +13,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          repositories: qoodish
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
# Summary

Replace the default `GITHUB_TOKEN` with a GitHub App installation token so that the semver tag pushed by release-please triggers the `prod.yaml` deployment workflow. The token is scoped to the `qoodish` repository.

# Motivation

Tags and releases created by `GITHUB_TOKEN` do not trigger other GitHub Actions workflows. Using a GitHub App token bypasses this restriction while keeping the credential short-lived (1-hour TTL) and repository-scoped.

# Changes

- Add `actions/create-github-app-token@v2` step to generate a scoped installation token
- Pass the token to `googleapis/release-please-action@v4` via the `token` input

# Setup required

Register the following in repository Settings → Secrets and variables → Actions:

| Kind | Name | Value |
|---|---|---|
| Variable | `RELEASE_APP_ID` | GitHub App ID (integer) |
| Secret | `RELEASE_APP_PRIVATE_KEY` | GitHub App private key (PEM) |

🤖 Generated with [Claude Code](https://claude.ai/code)