### PR TITLE
fix: delete Identity Platform account on destroy

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -11,7 +11,6 @@ env:
   ARTIFACT_REGISTRY: asia-northeast1-docker.pkg.dev
   SERVICE_NAME: qoodish-api
   JOB_NAME: qoodish-runner
-  BRANCH_NAME: ${{ github.head_ref }}
 
 jobs:
   test:
@@ -161,12 +160,6 @@ jobs:
           service_account: github-actions@qoodish-common.iam.gserviceaccount.com
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
-      - name: Normalize branch name for Cloud Run tag
-        id: normalize
-        run: |
-          NORMALIZED_TAG=$(echo "${{ env.BRANCH_NAME }}" | sed 's/[._/]/-/g')
-          echo "tag=$NORMALIZED_TAG" >> $GITHUB_OUTPUT
-          echo "Normalized tag: $NORMALIZED_TAG"
       - name: Deploy Service using kustomize
         working-directory: run/dev/api
         env:
@@ -188,6 +181,6 @@ jobs:
           CLOUDSDK_CORE_DISABLE_PROMPTS: 1
         run: |
           gcloud beta run services update-traffic ${{ env.SERVICE_NAME }} \
-            --update-tags=${{ steps.normalize.outputs.tag }}=LATEST \
+            --update-tags=pr-${{ github.event.number }}=LATEST \
             --project=$PROJECT_ID \
             --region=$REGION

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,6 +30,8 @@ class UsersController < ApplicationController
   end
 
   def destroy
+    current_user.reviews.preload(:images, :votes).load
+    current_user.maps.preload(:invites, :follows, :votes, reviews: [:images, :votes]).load
     current_user.destroy!
   end
 

--- a/app/models/google_auth.rb
+++ b/app/models/google_auth.rb
@@ -1,6 +1,5 @@
 class GoogleAuth
   CLIENT_CERT_URL = 'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com'.freeze
-  FCM_SCOPE = 'https://www.googleapis.com/auth/firebase.messaging'.freeze
 
   def initialize
     @project_id = ENV['GOOGLE_PROJECT_ID']
@@ -16,10 +15,12 @@ class GoogleAuth
     Google::Auth::IDTokens.verify_oidc(jwt, aud: aud)
   end
 
+  def make_credentials(scopes)
+    Google::Auth::ServiceAccountCredentials.make_creds(scope: scopes)
+  end
+
   def fetch_access_token(scope)
-    authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
-      scope: scope
-    )
+    authorizer = make_credentials(scope)
     token = authorizer.fetch_access_token!
     token['access_token']
   end

--- a/app/models/identity_platform.rb
+++ b/app/models/identity_platform.rb
@@ -1,0 +1,41 @@
+class IdentityPlatform
+  ENDPOINT = 'https://identitytoolkit.googleapis.com'.freeze
+  SCOPES = 'https://www.googleapis.com/auth/cloud-platform'.freeze
+  USER_NOT_FOUND = 'USER_NOT_FOUND'.freeze
+
+  def delete_account(uid)
+    access_token = google_auth.fetch_access_token(SCOPES)
+    response = faraday.post(
+      '/v1/accounts:delete',
+      { localId: uid, targetProjectId: ENV['GOOGLE_PROJECT_ID'] },
+      'Authorization' => "Bearer #{access_token}"
+    )
+
+    return if response.success?
+
+    error_message = response.body&.dig('error', 'message')
+    if error_message == USER_NOT_FOUND
+      Rails.logger.warn("Identity Platform account not found for uid: #{uid}")
+      return
+    end
+
+    Rails.logger.error("Identity Platform error: #{error_message}")
+    raise Exceptions::InternalServerError
+  rescue Faraday::Error => e
+    Rails.logger.error(e)
+    raise Exceptions::InternalServerError
+  end
+
+  private
+
+  def faraday
+    @faraday ||= Faraday.new(ENDPOINT) do |f|
+      f.request :json
+      f.response :json
+    end
+  end
+
+  def google_auth
+    @google_auth ||= GoogleAuth.new
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -51,11 +51,13 @@ class Image < ApplicationRecord
     file.delete
   end
 
+  def google_auth
+    @google_auth ||= GoogleAuth.new
+  end
+
   def storage
     @storage ||= Google::Cloud::Storage.new(
-      credentials: Google::Auth::ServiceAccountCredentials.make_creds(
-        scope: STORAGE_SCOPES
-      )
+      credentials: google_auth.make_credentials(STORAGE_SCOPES)
     )
   end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,6 +4,7 @@ class Notification < ApplicationRecord
   belongs_to :recipient, polymorphic: true
 
   KEYS = %w[followed invited liked comment].freeze
+  FCM_SCOPE = 'https://www.googleapis.com/auth/firebase.messaging'.freeze
 
   validates :notifiable_type,
             inclusion: {
@@ -55,7 +56,7 @@ class Notification < ApplicationRecord
 
   def bloadcast_web_push
     google_auth = GoogleAuth.new
-    access_token = google_auth.fetch_access_token(GoogleAuth::FCM_SCOPE)
+    access_token = google_auth.fetch_access_token(FCM_SCOPE)
 
     headers = {
       'Content-Type': 'application/json',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
               maximum: 160
             }
 
+  before_destroy :delete_id_platform_account
   after_create :create_default_map
 
   scope :search_by_name, lambda { |name|
@@ -115,6 +116,16 @@ class User < ApplicationRecord
 
   def liked?(votable)
     votable.voters.any? { |voter| voter.id == id }
+  end
+
+  private
+
+  def delete_id_platform_account
+    id_platform.delete_account(uid)
+  end
+
+  def id_platform
+    @id_platform ||= IdentityPlatform.new
   end
 
   def create_default_map

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -26,4 +26,19 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal res['id'], users(:you).id
     assert res['push_notification'].blank?
   end
+
+  test 'delete account should be success' do
+    uid = users(:me).uid
+
+    stub_google_auth(users(:me)) do
+      stub_identity_platform do
+        stub_cloud_storage do
+          delete "/users/#{uid}", headers: { 'Authorization': 'Bearer dummytoken' }
+        end
+      end
+    end
+
+    assert_response :no_content
+    assert_nil User.find_by(uid: uid)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,14 @@ class ActiveSupport::TestCase
     GoogleAuth.stub :new, GoogleAuthMock.new(current_user), &block
   end
 
+  def stub_identity_platform(&block)
+    IdentityPlatform.stub :new, IdentityPlatformMock.new, &block
+  end
+
+  def stub_cloud_storage(&block)
+    Google::Cloud::Storage.stub :new, CloudStorageMock.new, &block
+  end
+
   class GoogleAuthMock
     def initialize(current_user)
       @current_user = current_user
@@ -22,6 +30,30 @@ class ActiveSupport::TestCase
         'sub' => @current_user.uid,
         'name' => @current_user.name
       }
+    end
+
+    def make_credentials(_scopes)
+      nil
+    end
+
+    def fetch_access_token(_scope)
+      'dummy_access_token'
+    end
+  end
+
+  class IdentityPlatformMock
+    def delete_account(_uid); end
+  end
+
+  class CloudStorageMock
+    def bucket(_name)
+      BucketMock.new
+    end
+
+    class BucketMock
+      def file(_path)
+        nil
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary

When a user deletes their account via `DELETE /users/:uid`, the corresponding Identity Platform (Firebase Authentication) account was not deleted server-side. This fix removes the account from both systems atomically.

fixes #528 

# Motivation

Without this fix, a deleted user's Firebase account remains active, allowing them to re-authenticate with the same credentials even after account deletion.

# Changes

- Add `IdentityPlatform` PORO that calls the admin REST API (`POST /v1/accounts:delete` with `localId`) using service account credentials
- Invoke via `before_destroy` callback on `User` so that if Identity Platform deletion fails, the DB record is not deleted, keeping both systems consistent
- Preload associations in `UsersController#destroy` to prevent N+1 queries during the `dependent: :destroy` cascade
- Extract `GoogleAuth#make_credentials` and route `Image#storage` through it for consistent credential management and test coverage
- Move `FCM_SCOPE` from `GoogleAuth` to `Notification` where it belongs
- Use PR number as Cloud Run traffic tag in dev workflow to avoid the 46-character combined length limit with service name

🤖 Generated with [Claude Code](https://claude.ai/code)