### PR TITLE
feat: integrate Cloudflare Images upload flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'rails', '~> 7.2.2.1'
 # gem 'bcrypt', '~> 3.1.7'
 
 gem 'bootsnap', require: false
+gem 'faraday'
+gem 'faraday-multipart', require: 'faraday/multipart'
 gem 'google-cloud-storage'
 gem 'jbuilder'
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     globalid (1.2.1)
@@ -180,6 +182,7 @@ GEM
     minitest (5.25.5)
     msgpack (1.8.0)
     multi_json (1.15.0)
+    multipart-post (2.4.1)
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
@@ -539,6 +542,8 @@ DEPENDENCIES
   bootsnap
   bullet
   dotenv-rails
+  faraday
+  faraday-multipart
   google-cloud-storage
   jbuilder
   jwt

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :handle_record_not_found
   rescue_from ActionController::ParameterMissing, with: :handle_parameter_missing
   rescue_from ActiveRecord::RecordInvalid, with: :handle_record_invalid
+  rescue_from ActiveRecord::RecordNotSaved, with: :handle_record_invalid
+  rescue_from Faraday::Error, with: :handle_faraday_error
 
   def routing_error
     exception = Exceptions::NotFound.new("No route matches [#{request.request_method}] '#{request.path}'")
@@ -37,6 +39,11 @@ class ApplicationController < ActionController::API
   def handle_record_invalid(exception)
     Rails.logger.warn(exception)
     render_error(Exceptions::UnprocessableContent.new(exception.message))
+  end
+
+  def handle_faraday_error(exception)
+    Rails.logger.error(exception)
+    render_error(Exceptions::InternalServerError.new)
   end
 
   def current_user

--- a/app/controllers/guest/maps/collaborators_controller.rb
+++ b/app/controllers/guest/maps/collaborators_controller.rb
@@ -1,6 +1,6 @@
 class Guest::Maps::CollaboratorsController < ApplicationController
   def index
     map = Map.public_open.find_by(id: params[:map_id])
-    @collaborators = map ? map.followers : []
+    @collaborators = map ? map.followers.preload(:images) : []
   end
 end

--- a/app/controllers/guest/maps/reviews_controller.rb
+++ b/app/controllers/guest/maps/reviews_controller.rb
@@ -2,7 +2,7 @@ class Guest::Maps::ReviewsController < ApplicationController
   def index
     @reviews = Review
                .public_open
-               .preload(:map, :user, :images, { comments: :user })
+               .preload(:map, { user: :images }, :images, { comments: { user: :images } })
                .where(map_id: params[:map_id])
                .order(created_at: :desc)
   end

--- a/app/controllers/guest/maps_controller.rb
+++ b/app/controllers/guest/maps_controller.rb
@@ -2,7 +2,7 @@ class Guest::MapsController < ApplicationController
   def show
     @map = Map
            .public_open
-           .preload(:user)
+           .preload(:images, user: :images)
            .find_by!(id: params[:id])
   end
 
@@ -10,30 +10,30 @@ class Guest::MapsController < ApplicationController
     @maps = if params[:input].present?
               Map
                 .public_open
-                .preload(:user)
+                .preload(:images, user: :images)
                 .search_by_words(params[:input].strip.split(/[[:blank:]]+/))
                 .order(created_at: :desc)
                 .limit(20)
             elsif params[:recent].present?
               Map
                 .public_open
-                .preload(:user)
+                .preload(:images, user: :images)
                 .order(created_at: :desc)
                 .limit(12)
             elsif params[:active]
               Map
                 .public_open
-                .preload(:user)
+                .preload(:images, user: :images)
                 .active
             elsif params[:popular]
               Map
                 .public_open
-                .preload(:user)
+                .preload(:images, user: :images)
                 .popular
             elsif params[:recommend]
               Map
                 .public_open
-                .preload(:user)
+                .preload(:images, user: :images)
                 .order(created_at: :desc)
                 .sample(10)
             else

--- a/app/controllers/guest/reviews_controller.rb
+++ b/app/controllers/guest/reviews_controller.rb
@@ -2,7 +2,7 @@ class Guest::ReviewsController < ApplicationController
   def show
     @review = Review
               .public_open
-              .preload(:map, :user, :images, { comments: :user })
+              .preload(:map, { user: :images }, :images, { comments: { user: :images } })
               .find_by!(id: params[:id])
   end
 
@@ -11,13 +11,13 @@ class Guest::ReviewsController < ApplicationController
                  Review
                    .public_open
                    .limit(8)
-                   .preload(:map, :user, :images, { comments: :user })
+                   .preload(:map, { user: :images }, :images, { comments: { user: :images } })
                    .order(created_at: :desc)
                elsif params[:popular]
                  Review
                    .public_open
                    .popular
-                   .preload(:map, :user, :images, { comments: :user })
+                   .preload(:map, { user: :images }, :images, { comments: { user: :images } })
                else
                  raise Exceptions::BadRequest
                end

--- a/app/controllers/guest/users/maps_controller.rb
+++ b/app/controllers/guest/users/maps_controller.rb
@@ -3,7 +3,7 @@ class Guest::Users::MapsController < ApplicationController
     @maps = Map
             .public_open
             .where(user_id: params[:user_id])
-            .preload(:user)
+            .preload(:images, user: :images)
             .order(created_at: :desc)
   end
 end

--- a/app/controllers/guest/users/reviews_controller.rb
+++ b/app/controllers/guest/users/reviews_controller.rb
@@ -5,13 +5,13 @@ class Guest::Users::ReviewsController < ApplicationController
         Review
           .public_open
           .where(user_id: params[:user_id])
-          .preload(:map, :user, :images, { comments: :user })
+          .preload(:map, { user: :images }, :images, { comments: { user: :images } })
           .feed_before(params[:next_timestamp])
       else
         Review
           .public_open
           .where(user_id: params[:user_id])
-          .preload(:map, :user, :images, { comments: :user })
+          .preload(:map, { user: :images }, :images, { comments: { user: :images } })
           .latest_feed
       end
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,11 @@
+class ImagesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    result = Cloudflare::Images.new.create_direct_upload
+    image = current_user.owned_images.create!(
+      url: Cloudflare::Images.delivery_url(result[:id])
+    )
+    render json: { id: image.id, upload_url: result[:upload_url] }
+  end
+end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -5,7 +5,7 @@ class InvitesController < ApplicationController
     @invites =
       current_user
       .invites
-      .includes(:invitable)
+      .includes({ invitable: :images }, { sender: :images })
       .order(created_at: :desc)
       .reject { |invite| invite.sender.blank? || invite.invitable.blank? }
   end

--- a/app/controllers/maps/collaborators_controller.rb
+++ b/app/controllers/maps/collaborators_controller.rb
@@ -4,7 +4,7 @@ module Maps
 
     def index
       @map = current_user.referenceable_maps.find_by(id: params[:map_id])
-      @collaborators = @map ? @map.followers : []
+      @collaborators = @map ? @map.followers.preload(:images) : []
     end
   end
 end

--- a/app/controllers/maps/follows_controller.rb
+++ b/app/controllers/maps/follows_controller.rb
@@ -3,34 +3,41 @@ module Maps
     before_action :authenticate_user!
 
     def create
-      map = if params[:invite_id]
-              invite = current_user.invites.find_by!(id: params[:invite_id], expired: false)
-              invite.update!(expired: true)
-              invite.invitable
-            else
-              current_user
-                .referenceable_maps
-                .preload(:user)
-                .find_by!(id: params[:map_id])
-            end
+      @map = if params[:invite_id]
+               invite = current_user.invites.find_by!(id: params[:invite_id], expired: false)
+               invite.update!(expired: true)
+               invite.invitable
+             else
+               current_user
+                 .referenceable_maps
+                 .find_by!(id: params[:map_id])
+             end
 
-      current_user.follow!(map)
+      current_user.follow!(@map)
 
-      @map = map.reload
+      preload_map_for_serialization
     end
 
     def destroy
-      map =
+      @map =
         current_user
         .following_maps
-        .preload(:user)
         .find_by!(id: params[:map_id])
 
-      raise Exceptions::MapOwnerCannotRemoved if current_user.map_owner?(map)
+      raise Exceptions::MapOwnerCannotRemoved if current_user.map_owner?(@map)
 
-      current_user.unfollow!(map)
+      current_user.unfollow!(@map)
 
-      @map = map.reload
+      preload_map_for_serialization
+    end
+
+    private
+
+    def preload_map_for_serialization
+      ActiveRecord::Associations::Preloader.new(
+        records: [@map],
+        associations: [:images, { user: :images }]
+      ).call
     end
 
     def follow_params

--- a/app/controllers/maps/reviews_controller.rb
+++ b/app/controllers/maps/reviews_controller.rb
@@ -6,7 +6,7 @@ module Maps
       @reviews = current_user
                  .referenceable_reviews
                  .where(map_id: params[:map_id])
-                 .preload(:map, :user, :images, { comments: :user }, :voters, :votes)
+                 .preload(:map, { user: :images }, :images, { comments: { user: :images } }, :voters, :votes)
                  .order(created_at: :desc)
     end
 
@@ -14,39 +14,43 @@ module Maps
       @review =
         current_user
         .referenceable_reviews
-        .preload(:map, :user, :images, { comments: :user }, :voters, :votes)
+        .preload(:map, { user: :images }, :images, { comments: { user: :images } }, :voters, :votes)
         .find_by!(id: params[:id])
     end
 
     def create
-      map =
-        current_user
+      current_user
         .postable_maps
         .find_by!(id: params[:map_id])
 
-      ActiveRecord::Base.transaction do
-        @review = current_user.reviews.create!(review_params)
-
-        images_params[:images].each do |image|
-          @review.images.create!(
-            url: image[:url]
-          )
-        end
-      end
+      @review = current_user.reviews.create!(review_params)
     end
 
     private
 
     def review_params
-      params
-        .permit(:map_id, :name, :comment, :latitude, :longitude)
-        .to_h
+      attrs = params.permit(:map_id, :name, :comment, :latitude, :longitude, image_ids: []).to_h
+      attrs['image_ids'] ||= legacy_image_ids_from_images
+      attrs
     end
 
-    def images_params
-      params
-        .permit(images: [:url])
-        .to_h
+    # Phase 1 backward compatibility: convert legacy `images: [{url: "..."}]`
+    # into an `image_ids` array. Remove together with the legacy schema in Phase 3.
+    def legacy_image_ids_from_images
+      return unless params.key?(:images)
+      return [] if params[:images].blank?
+
+      params.permit(images: [:url]).fetch(:images, []).filter_map do |image|
+        url = image[:url]
+        next if url.blank?
+
+        # Find globally to avoid colliding with Image's global url uniqueness
+        # when the URL already belongs to another user; drop foreign-owned URLs.
+        record = Image.find_or_create_by!(url: url) { |img| img.user_id = current_user.id }
+        next if record.user_id != current_user.id
+
+        record.id
+      end
     end
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -6,13 +6,13 @@ class MapsController < ApplicationController
               Map
                 .public_open
                 .unfollowing_by(current_user)
-                .preload(:user)
+                .preload(:images, user: :images)
                 .order(created_at: :desc)
                 .sample(10)
             else
               current_user
                 .following_maps
-                .preload(:user)
+                .preload(:images, user: :images)
                 .order(created_at: :desc)
             end
   end
@@ -21,17 +21,27 @@ class MapsController < ApplicationController
     @map =
       current_user
       .referenceable_maps
-      .preload(:user)
+      .preload(:images, user: :images)
       .find_by!(id: params[:id])
   end
 
   def create
     @map = current_user.maps.create!(map_params)
+
+    ActiveRecord::Associations::Preloader.new(
+      records: [@map],
+      associations: :images
+    ).call
   end
 
   def update
-    @map = current_user.maps.preload(:user).find_by!(id: params[:id])
+    @map = current_user.maps.find_by!(id: params[:id])
     @map.update!(map_params)
+
+    ActiveRecord::Associations::Preloader.new(
+      records: [@map],
+      associations: :images
+    ).call
   end
 
   def destroy
@@ -41,8 +51,24 @@ class MapsController < ApplicationController
   private
 
   def map_params
-    params
-      .permit(:name, :description, :private, :invitable, :shared, :latitude, :longitude, :image_url)
-      .to_h
+    attrs = params.permit(:name, :description, :private, :invitable, :shared, :latitude, :longitude, image_ids: []).to_h
+    attrs['image_ids'] ||= legacy_image_ids_from_url
+    attrs
+  end
+
+  # Phase 1 backward compatibility: convert legacy `image_url` (URL) into
+  # an `image_ids` array. Remove together with the legacy column in Phase 3.
+  def legacy_image_ids_from_url
+    return unless params.key?(:image_url)
+
+    url = params.permit(:image_url)[:image_url]
+    return [] if url.blank?
+
+    # Find globally to avoid colliding with Image's global url uniqueness when
+    # the URL already belongs to another user; silently drop foreign-owned URLs.
+    image = Image.find_or_create_by!(url: url) { |img| img.user_id = current_user.id }
+    return [] if image.user_id != current_user.id
+
+    [image.id]
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,10 +6,12 @@ class NotificationsController < ApplicationController
       current_user
       .notifications
       .recent
-      .includes(:notifier, :notifiable)
+      .includes({ notifier: :images }, :notifiable)
       .reject do |notification|
         notification.notifier.blank? || notification.notifiable.blank?
       end
+
+    preload_notifiable_images(@notifications)
   end
 
   def update
@@ -19,5 +21,24 @@ class NotificationsController < ApplicationController
       .find_by!(id: params[:id])
 
     @notification.update!(read: true)
+  end
+
+  private
+
+  # Polymorphic preload: `includes(notifiable: :images)` cannot work because
+  # Comment has no :images association of its own (it serves images via
+  # commentable). Group notifiables by type and preload appropriately.
+  def preload_notifiable_images(notifications)
+    notifiables = notifications.map(&:notifiable)
+    direct = notifiables.reject { |n| n.is_a?(Comment) }
+    comments = notifiables.select { |n| n.is_a?(Comment) }
+
+    if direct.any?
+      ActiveRecord::Associations::Preloader.new(records: direct, associations: :images).call
+    end
+
+    if comments.any?
+      ActiveRecord::Associations::Preloader.new(records: comments, associations: { commentable: :images }).call
+    end
   end
 end

--- a/app/controllers/reviews/comments/likes_controller.rb
+++ b/app/controllers/reviews/comments/likes_controller.rb
@@ -18,7 +18,7 @@ module Reviews
         @review =
           current_user
           .referenceable_reviews
-          .preload(:map, :user, :images, { comments: :user })
+          .preload(:map, { user: :images }, :images, { comments: { user: :images } })
           .find_by!(id: params[:review_id])
 
         comment = @review.comments.find_by!(id: params[:comment_id])
@@ -30,7 +30,7 @@ module Reviews
         @review =
           current_user
           .referenceable_reviews
-          .preload(:map, :user, :images, { comments: :user })
+          .preload(:map, { user: :images }, :images, { comments: { user: :images } })
           .find_by!(id: params[:review_id])
 
         comment = @review.comments.find_by!(id: params[:comment_id])

--- a/app/controllers/reviews/comments_controller.rb
+++ b/app/controllers/reviews/comments_controller.rb
@@ -6,7 +6,7 @@ module Reviews
       @review =
         current_user
         .referenceable_reviews
-        .preload(:map, :user, :images, { comments: :user })
+        .preload(:map, { user: :images }, :images, { comments: { user: :images } })
         .find_by!(id: params[:review_id])
 
       @review.comments.create!(
@@ -21,7 +21,7 @@ module Reviews
       @review =
         current_user
         .referenceable_reviews
-        .preload(:map, :user, :images, { comments: :user })
+        .preload(:map, { user: :images }, :images, { comments: { user: :images } })
         .find_by!(id: params[:review_id])
 
       comment =

--- a/app/controllers/reviews/likes_controller.rb
+++ b/app/controllers/reviews/likes_controller.rb
@@ -15,7 +15,7 @@ module Reviews
       @review =
         current_user
         .referenceable_reviews
-        .preload(:map, :user, :images, { comments: :user })
+        .preload(:map, { user: :images }, :images, { comments: { user: :images } })
         .find_by!(id: params[:review_id])
 
       current_user.liked!(@review)
@@ -27,7 +27,7 @@ module Reviews
       @review =
         current_user
         .referenceable_reviews
-        .preload(:map, :user, :images, { comments: :user })
+        .preload(:map, { user: :images }, :images, { comments: { user: :images } })
         .find_by!(id: params[:review_id])
 
       current_user.unliked!(@review)

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -6,44 +6,23 @@ class ReviewsController < ApplicationController
                  Review
                    .following_by(current_user)
                    .feed_before(params[:next_timestamp])
-                   .preload(:map, :user, :images, { comments: :user }, :voters, :votes)
+                   .preload(:map, { user: :images }, :images, { comments: { user: :images } }, :voters, :votes)
                else
                  Review
                    .following_by(current_user)
                    .latest_feed
-                   .preload(:map, :user, :images, { comments: :user }, :voters, :votes)
+                   .preload(:map, { user: :images }, :images, { comments: { user: :images } }, :voters, :votes)
                end
   end
 
   def update
-    @review = current_user.reviews
-                          .preload(:map, :user, :images, { comments: :user }, :voters, :votes)
-                          .find_by!(id: params[:id])
+    @review = current_user.reviews.find_by!(id: params[:id])
+    @review.update!(review_params)
 
-    ActiveRecord::Base.transaction do
-      @review.update!(review_params)
-
-      if images_params[:images].blank?
-        @review.images.destroy_all
-      else
-        current_image_urls = @review.images.pluck(:url)
-        next_image_urls = images_params[:images].map { |image| image[:url] }
-
-        image_urls_will_be_deleted = current_image_urls - next_image_urls
-        image_urls_to_be_created = next_image_urls - current_image_urls
-
-        @review.images.where(url: image_urls_will_be_deleted).destroy_all
-        @review.reload
-
-        image_urls_to_be_created.each do |image_url|
-          @review.images.create!(
-            url: image_url
-          )
-        end
-      end
-
-      @review.reload
-    end
+    ActiveRecord::Associations::Preloader.new(
+      records: [@review],
+      associations: [:map, :images, { comments: { user: :images } }, :voters, :votes]
+    ).call
   end
 
   def destroy
@@ -53,14 +32,27 @@ class ReviewsController < ApplicationController
   private
 
   def review_params
-    params
-      .permit(:name, :comment, :latitude, :longitude)
-      .to_h
+    attrs = params.permit(:name, :comment, :latitude, :longitude, image_ids: []).to_h
+    attrs['image_ids'] ||= legacy_image_ids_from_images
+    attrs
   end
 
-  def images_params
-    params
-      .permit(images: [:url])
-      .to_h
+  # Phase 1 backward compatibility: convert legacy `images: [{url: "..."}]`
+  # into an `image_ids` array. Remove together with the legacy schema in Phase 3.
+  def legacy_image_ids_from_images
+    return unless params.key?(:images)
+    return [] if params[:images].blank?
+
+    params.permit(images: [:url]).fetch(:images, []).filter_map do |image|
+      url = image[:url]
+      next if url.blank?
+
+      # Find globally to avoid colliding with Image's global url uniqueness
+      # when the URL already belongs to another user; drop foreign-owned URLs.
+      record = Image.find_or_create_by!(url: url) { |img| img.user_id = current_user.id }
+      next if record.user_id != current_user.id
+
+      record.id
+    end
   end
 end

--- a/app/controllers/users/maps_controller.rb
+++ b/app/controllers/users/maps_controller.rb
@@ -7,12 +7,12 @@ module Users
                 if params[:following]
                   current_user
                     .following_maps
-                    .preload(:user)
+                    .preload(:images, user: :images)
                     .order(created_at: :desc)
                 else
                   current_user
                     .maps
-                    .preload(:user)
+                    .preload(:images, user: :images)
                     .order(created_at: :desc)
                 end
               else
@@ -21,13 +21,13 @@ module Users
                 if params[:following]
                   current_user
                     .referenceable_maps
-                    .preload(:user)
+                    .preload(:images, user: :images)
                     .where(id: Map.following_by(user))
                     .order(created_at: :desc)
                 else
                   current_user
                     .referenceable_maps
-                    .preload(:user)
+                    .preload(:images, user: :images)
                     .where(id: user.maps)
                     .order(created_at: :desc)
                 end

--- a/app/controllers/users/reviews_controller.rb
+++ b/app/controllers/users/reviews_controller.rb
@@ -7,12 +7,12 @@ module Users
                    if params[:next_timestamp]
                      current_user
                        .reviews
-                       .preload(:map, :user, :images, { comments: :user })
+                       .preload(:map, { user: :images }, :images, { comments: { user: :images } })
                        .feed_before(params[:next_timestamp])
                    else
                      current_user
                        .reviews
-                       .preload(:map, :user, :images, { comments: :user })
+                       .preload(:map, { user: :images }, :images, { comments: { user: :images } })
                        .latest_feed
                    end
                  else
@@ -21,13 +21,13 @@ module Users
                    if params[:next_timestamp]
                      user
                        .reviews
-                       .preload(:map, :user, :images, { comments: :user })
+                       .preload(:map, { user: :images }, :images, { comments: { user: :images } })
                        .referenceable_by(current_user)
                        .feed_before(params[:next_timestamp])
                    else
                      user
                        .reviews
-                       .preload(:map, :user, :images, { comments: :user })
+                       .preload(:map, { user: :images }, :images, { comments: { user: :images } })
                        .referenceable_by(current_user)
                        .latest_feed
                    end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,21 +25,42 @@ class UsersController < ApplicationController
   end
 
   def update
+    ActiveRecord::Associations::Preloader.new(
+      records: [current_user],
+      associations: [:images]
+    ).call
+
     current_user.update!(user_params)
     @user = current_user
   end
 
   def destroy
     current_user.reviews.preload(:images, :votes).load
-    current_user.maps.preload(:invites, :follows, :votes, reviews: [:images, :votes]).load
+    current_user.maps.preload(:images, :invites, :follows, :votes, reviews: [:images, :votes]).load
     current_user.destroy!
   end
 
   private
 
   def user_params
-    params
-      .permit(:name, :biography, :image_path)
-      .to_h
+    attrs = params.permit(:name, :biography, image_ids: []).to_h
+    attrs['image_ids'] ||= legacy_image_ids_from_path
+    attrs
+  end
+
+  # Phase 1 backward compatibility: convert legacy `image_path` (URL) into
+  # an `image_ids` array. Remove together with the legacy column in Phase 3.
+  def legacy_image_ids_from_path
+    return unless params.key?(:image_path)
+
+    url = params.permit(:image_path)[:image_path]
+    return [] if url.blank?
+
+    # Find globally to avoid colliding with Image's global url uniqueness when
+    # the URL already belongs to another user; silently drop foreign-owned URLs.
+    image = Image.find_or_create_by!(url: url) { |img| img.user_id = current_user.id }
+    return [] if image.user_id != current_user.id
+
+    [image.id]
   end
 end

--- a/app/models/cloudflare/images.rb
+++ b/app/models/cloudflare/images.rb
@@ -1,0 +1,159 @@
+module Cloudflare
+  class Images
+    ENDPOINT = 'https://api.cloudflare.com'.freeze
+    DELIVERY_HOST = 'imagedelivery.net'.freeze
+    SERVICE_IDENTIFIER = 'qoodish'.freeze
+
+    # Named variants pre-configured in the Cloudflare Images dashboard.
+    # Order matches the qoodish-web `ImageVariants` type. The pixel sizes
+    # come from the dashboard (avatar 80x80, card 400x400, hero 800x800,
+    # ogp 1200x630); the backend just references the variant names.
+    NAMED_VARIANTS = %i[avatar card hero ogp].freeze
+
+    # Map legacy `thumbnail_url(size)` arguments to the closest configured
+    # Cloudflare variant. Used by the legacy `thumbnail_url*` jbuilder
+    # fields until Phase 3 removes them.
+    LEGACY_SIZE_TO_VARIANT = {
+      '200x200' => 'avatar',
+      '400x400' => 'card',
+      '800x800' => 'hero'
+    }.freeze
+
+    def create_direct_upload
+      response = multipart_faraday.post(direct_upload_path) do |req|
+        req.headers['Authorization'] = "Bearer #{api_token}"
+        req.headers['Content-Type'] = 'multipart/form-data'
+        req.body = { id: build_custom_id, metadata: metadata_json }
+      end
+
+      raise_unless_success!(response)
+
+      result = response.body['result']
+      { id: result['id'], upload_url: result['uploadURL'] }
+    end
+
+    def upload_from_url(source_url)
+      response = multipart_faraday.post(images_path) do |req|
+        req.headers['Authorization'] = "Bearer #{api_token}"
+        req.headers['Content-Type'] = 'multipart/form-data'
+        req.body = { url: source_url, id: build_custom_id, metadata: metadata_json }
+        # Cloudflare fetches the source URL server-side; the default 10s is
+        # too tight when the origin (e.g. GCS) responds slowly.
+        req.options.timeout = 60
+      end
+
+      raise_unless_success!(response)
+
+      image_id = response.body.dig('result', 'id')
+      return nil if image_id.blank?
+
+      Cloudflare::Images.delivery_url(image_id)
+    end
+
+    def delete(image_id)
+      response = faraday.delete("#{images_path}/#{image_id}") do |req|
+        req.headers['Authorization'] = "Bearer #{api_token}"
+      end
+
+      return if response.success?
+
+      if response.status == 404
+        Rails.logger.warn("Cloudflare image #{image_id} not found")
+        return
+      end
+
+      Rails.logger.error("Cloudflare Images error: #{response.body}")
+      raise Exceptions::InternalServerError
+    end
+
+    def self.delivery_url(image_id, variant: 'public')
+      "https://#{DELIVERY_HOST}/#{ENV.fetch('CLOUDFLARE_IMAGES_ACCOUNT_HASH')}/#{image_id}/#{variant}"
+    end
+
+    # Replace the variant segment of a delivery URL with the given variant
+    # name. The variant must be configured in the Cloudflare Images dashboard.
+    def self.variant_url(url, variant)
+      url.sub(%r{/[^/]+\z}, "/#{variant}")
+    end
+
+    # Legacy adapter: translates a `thumbnail_url(size)` size argument into a
+    # configured Cloudflare variant name. Falls back to `public` for unknown
+    # sizes so callers always get a working URL.
+    def self.variant_url_for_legacy_size(url, size)
+      variant_url(url, LEGACY_SIZE_TO_VARIANT.fetch(size, 'public'))
+    end
+
+    def self.extract_id(url)
+      return nil if url.blank?
+
+      uri = URI.parse(url)
+      return nil unless uri.host == DELIVERY_HOST
+
+      # path layout: /<account-hash>/<image-id...>/<variant>
+      # image-id may contain slashes when a custom ID is used.
+      parts = uri.path.split('/').reject(&:empty?)
+      return nil if parts.size < 3
+
+      parts[1..-2].join('/')
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    private
+
+    def build_custom_id
+      "#{SERVICE_IDENTIFIER}/#{SecureRandom.uuid}"
+    end
+
+    def metadata_json
+      { app: SERVICE_IDENTIFIER, env: app_env }.to_json
+    end
+
+    # APP_ENV distinguishes deployments that all run with RAILS_ENV=production
+    # (prod and dev Cloud Run services). Falls back to Rails.env for local runs
+    # where APP_ENV is not set.
+    def app_env
+      ENV.fetch('APP_ENV', Rails.env)
+    end
+
+    def raise_unless_success!(response)
+      return if response.success? && response.body.is_a?(Hash) && response.body['success']
+
+      Rails.logger.error("Cloudflare Images error: #{response.body}")
+      raise Exceptions::InternalServerError
+    end
+
+    def account_id
+      ENV.fetch('CLOUDFLARE_ACCOUNT_ID')
+    end
+
+    def api_token
+      ENV.fetch('CLOUDFLARE_IMAGES_API_TOKEN')
+    end
+
+    def direct_upload_path
+      "/client/v4/accounts/#{account_id}/images/v2/direct_upload"
+    end
+
+    def images_path
+      "/client/v4/accounts/#{account_id}/images/v1"
+    end
+
+    def faraday
+      @faraday ||= Faraday.new(ENDPOINT) do |f|
+        f.options.timeout = 10
+        f.options.open_timeout = 5
+        f.response :json
+      end
+    end
+
+    def multipart_faraday
+      @multipart_faraday ||= Faraday.new(ENDPOINT) do |f|
+        f.options.timeout = 10
+        f.options.open_timeout = 5
+        f.request :multipart
+        f.response :json
+      end
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -19,6 +19,14 @@ class Comment < ApplicationRecord
     commentable.thumbnail_url
   end
 
+  def image_url
+    commentable.image_url
+  end
+
+  def image_variants
+    commentable.image_variants
+  end
+
   def on_yourself?
     user.id == commentable.user.id
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,8 +1,9 @@
 class Image < ApplicationRecord
-  belongs_to :review
+  self.ignored_columns = %w[review_id]
 
-  validates :review_id,
-            presence: true
+  belongs_to :user
+  belongs_to :imageable, polymorphic: true, optional: true
+
   validates :url,
             presence: true,
             uniqueness: true,
@@ -11,57 +12,55 @@ class Image < ApplicationRecord
               with: /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/,
               message: I18n.t('messages.api.invalid_uri')
             }
+  validate :uploader_matches_imageable_owner,
+           if: -> { imageable && (imageable_id_changed? || imageable_type_changed?) }
 
-  before_destroy :delete_object
+  before_destroy :delete_cloudflare_image
 
-  STORAGE_SCOPES = [
-    'https://www.googleapis.com/auth/cloud-platform',
-    'https://www.googleapis.com/auth/devstorage.read_write'
-  ].freeze
+  def thumbnail_url(size = '200x200')
+    return '' if url.blank?
+    return Cloudflare::Images.variant_url_for_legacy_size(url, size) if url.include?(Cloudflare::Images::DELIVERY_HOST)
+
+    ext = File.extname(url)
+    "#{ENV['CLOUD_STORAGE_ENDPOINT']}/#{ENV['CLOUD_STORAGE_BUCKET_NAME']}/images/thumbnails/" \
+      "#{File.basename(file_name, ext)}_#{size}#{ext}"
+  end
+
+  def variants
+    if url.include?(Cloudflare::Images::DELIVERY_HOST)
+      Cloudflare::Images::NAMED_VARIANTS
+        .index_with { |variant| Cloudflare::Images.variant_url(url, variant) }
+        .merge(url: url)
+    else
+      # GCS transition fallback: map to pre-generated thumbnails where
+      # available, otherwise use the original URL.
+      {
+        url: url,
+        avatar: thumbnail_url('200x200'),
+        card: thumbnail_url('400x400'),
+        hero: thumbnail_url('800x800'),
+        ogp: url
+      }
+    end
+  end
+
+  private
+
+  def uploader_matches_imageable_owner
+    expected_user_id = imageable.is_a?(User) ? imageable.id : imageable.user_id
+    errors.add(:user, :invalid) unless user_id == expected_user_id
+  end
 
   def file_name
     File.basename(CGI.unescape(url))
   end
 
-  def file_name_was
-    return '' if url_was.blank?
+  def delete_cloudflare_image
+    image_id = Cloudflare::Images.extract_id(url)
+    return if image_id.blank?
 
-    File.basename(CGI.unescape(url_was))
-  end
-
-  def ext
-    File.extname(url)
-  end
-
-  def thumbnail_url(size = '200x200')
-    "#{ENV['CLOUD_STORAGE_ENDPOINT']}/#{ENV['CLOUD_STORAGE_BUCKET_NAME']}/images/thumbnails/#{File.basename(file_name,
-                                                                                                            ext)}_#{size}#{ext}"
-  end
-
-  private
-
-  def delete_object
-    file = bucket.file("images/#{file_name}")
-
-    if file.blank?
-      Rails.logger.warn("Object #{file_name} not found.")
-      return
-    end
-
-    file.delete
-  end
-
-  def google_auth
-    @google_auth ||= GoogleAuth.new
-  end
-
-  def storage
-    @storage ||= Google::Cloud::Storage.new(
-      credentials: google_auth.make_credentials(STORAGE_SCOPES)
-    )
-  end
-
-  def bucket
-    @bucket ||= storage.bucket(ENV['CLOUD_STORAGE_BUCKET_NAME'])
+    Cloudflare::Images.new.delete(image_id)
+  rescue Exceptions::InternalServerError, Faraday::Error => e
+    Rails.logger.warn("Cloudflare delete failed for image #{id}: #{e.message}")
   end
 end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -1,4 +1,6 @@
 class Map < ApplicationRecord
+  self.ignored_columns = %w[image_url]
+
   belongs_to :user
   has_many :reviews, dependent: :destroy
   has_many :notifications, as: :notifiable
@@ -7,6 +9,7 @@ class Map < ApplicationRecord
   has_many :followers, through: :follows, source: :follower, source_type: User.name
   has_many :votes, as: :votable, dependent: :destroy
   has_many :voters, through: :votes, source: :voter, source_type: User.name
+  has_many :images, as: :imageable, dependent: :destroy
 
   validates :name,
             presence: {
@@ -35,6 +38,7 @@ class Map < ApplicationRecord
             presence: {
               message: I18n.t('messages.api.map_owner_not_specified')
             }
+  validates :images, length: { maximum: 1 }
 
   before_validation :remove_carriage_return
   after_create :follow_by_owner
@@ -93,17 +97,36 @@ class Map < ApplicationRecord
   }
 
   def thumbnail_url(size = '200x200')
-    return '' if image_url.blank?
+    primary = images.first
+    return '' if primary&.url.blank?
+    return Cloudflare::Images.variant_url_for_legacy_size(primary.url, size) if primary.url.include?(Cloudflare::Images::DELIVERY_HOST)
 
-    ext = File.extname(image_url)
-    "#{ENV['CLOUD_STORAGE_ENDPOINT']}/#{ENV['CLOUD_STORAGE_BUCKET_NAME']}/maps/thumbnails/#{File.basename(image_name,
-                                                                                                          ext)}_#{size}#{ext}"
+    ext = File.extname(primary.url)
+    "#{ENV['CLOUD_STORAGE_ENDPOINT']}/#{ENV['CLOUD_STORAGE_BUCKET_NAME']}/maps/thumbnails/" \
+      "#{File.basename(File.basename(CGI.unescape(primary.url)), ext)}_#{size}#{ext}"
   end
 
-  def image_name
-    return '' if image_url.blank?
+  def image_url
+    images.first&.url.to_s
+  end
 
-    File.basename(CGI.unescape(image_url))
+  def image_variants
+    primary = images.first
+    return nil unless primary
+
+    if primary.url.include?(Cloudflare::Images::DELIVERY_HOST)
+      Cloudflare::Images::NAMED_VARIANTS
+        .index_with { |variant| Cloudflare::Images.variant_url(primary.url, variant) }
+        .merge(url: primary.url)
+    else
+      {
+        url: primary.url,
+        avatar: thumbnail_url('200x200'),
+        card: thumbnail_url('400x400'),
+        hero: thumbnail_url('800x800'),
+        ogp: primary.url
+      }
+    end
   end
 
   def lat

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-require 'google/cloud/storage'
-
 FEED_PER_PAGE = 12
 MAX_IMAGE_COUNT_PER_REVIEW = 4
 
 class Review < ApplicationRecord
   belongs_to :user
   belongs_to :map
-  has_many :images, dependent: :destroy
+  has_many :images, as: :imageable, dependent: :destroy
   has_many :notifications, as: :notifiable
   has_many :comments, as: :commentable
   has_many :votes, as: :votable, dependent: :destroy
@@ -77,7 +75,15 @@ class Review < ApplicationRecord
   }
 
   def thumbnail_url(size = '200x200')
-    images.exists? ? images.first.thumbnail_url(size) : ''
+    images.first&.thumbnail_url(size).to_s
+  end
+
+  def image_url
+    images.first&.url.to_s
+  end
+
+  def image_variants
+    images.first&.variants
   end
 
   def lat

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  self.ignored_columns = %w[image_path]
+
   has_many :devices, dependent: :destroy
   has_many :maps, dependent: :destroy
   has_many :reviews, dependent: :destroy
@@ -7,6 +9,8 @@ class User < ApplicationRecord
   has_many :invites, as: :recipient
   has_many :follows, as: :follower, dependent: :destroy
   has_many :votes, as: :voter, dependent: :destroy
+  has_many :owned_images, class_name: 'Image', dependent: :destroy
+  has_many :images, as: :imageable, dependent: :destroy
   has_one :push_notification, dependent: :destroy
 
   validates :uid,
@@ -19,6 +23,7 @@ class User < ApplicationRecord
               allow_blank: true,
               maximum: 160
             }
+  validates :images, length: { maximum: 1 }
 
   before_destroy :delete_id_platform_account
   after_create :create_default_map
@@ -29,18 +34,36 @@ class User < ApplicationRecord
   }
 
   def thumbnail_url(size = '200x200')
-    return '' if image_path.blank?
+    primary = images.first
+    return '' if primary&.url.blank?
+    return Cloudflare::Images.variant_url_for_legacy_size(primary.url, size) if primary.url.include?(Cloudflare::Images::DELIVERY_HOST)
 
-    ext = File.extname(image_path)
-    "#{ENV['CLOUD_STORAGE_ENDPOINT']}/#{ENV['CLOUD_STORAGE_BUCKET_NAME']}/profile/thumbnails/#{File.basename(
-      image_name, ext
-    )}_#{size}#{ext}"
+    ext = File.extname(primary.url)
+    "#{ENV['CLOUD_STORAGE_ENDPOINT']}/#{ENV['CLOUD_STORAGE_BUCKET_NAME']}/profile/thumbnails/" \
+      "#{File.basename(File.basename(CGI.unescape(primary.url)), ext)}_#{size}#{ext}"
   end
 
-  def image_name
-    return '' if image_path.blank?
+  def image_url
+    images.first&.url.to_s
+  end
 
-    File.basename(CGI.unescape(image_path))
+  def image_variants
+    primary = images.first
+    return nil unless primary
+
+    if primary.url.include?(Cloudflare::Images::DELIVERY_HOST)
+      Cloudflare::Images::NAMED_VARIANTS
+        .index_with { |variant| Cloudflare::Images.variant_url(primary.url, variant) }
+        .merge(url: primary.url)
+    else
+      {
+        url: primary.url,
+        avatar: thumbnail_url('200x200'),
+        card: thumbnail_url('400x400'),
+        hero: thumbnail_url('800x800'),
+        ogp: primary.url
+      }
+    end
   end
 
   def author?(post)

--- a/app/views/invites/_invite.jbuilder
+++ b/app/views/invites/_invite.jbuilder
@@ -2,13 +2,17 @@ json.id invite.id
 json.invitable do
   json.id invite.invitable_id
   json.type invite.invitable_name
-  json.image_url invite.invitable.thumbnail_url
+  json.image invite.invitable.image_variants
+  json.image_url invite.invitable.image_url
+  json.thumbnail_url invite.invitable.thumbnail_url
   json.name invite.invitable.name
   json.description invite.invitable.description
 end
 json.sender do
   json.id invite.sender_id
   json.name invite.sender.name
+  json.image invite.sender.image_variants
+  json.image_url invite.sender.image_url
   json.profile_image_url invite.sender.thumbnail_url
 end
 json.expired invite.expired

--- a/app/views/maps/collaborators/_collaborator.jbuilder
+++ b/app/views/maps/collaborators/_collaborator.jbuilder
@@ -1,5 +1,7 @@
 json.id collaborator.id
 json.name collaborator.name
+json.image collaborator.image_variants
+json.image_url collaborator.image_url
 json.profile_image_url collaborator.thumbnail_url
 json.owner collaborator.map_owner?(@map)
 json.editable current_user.map_owner?(@map)

--- a/app/views/notifications/_notification.jbuilder
+++ b/app/views/notifications/_notification.jbuilder
@@ -4,11 +4,15 @@ json.click_action notification.click_action
 json.notifiable do
   json.id notification.notifiable_id
   json.type notification.notifiable_type.downcase
+  json.image notification.notifiable.image_variants
+  json.image_url notification.notifiable.image_url
   json.thumbnail_url notification.notifiable.thumbnail_url
 end
 json.notifier do
   json.id notification.notifier_id
   json.name notification.notifier.name
+  json.image notification.notifier.image_variants
+  json.image_url notification.notifier.image_url
   json.profile_image_url notification.notifier.thumbnail_url
 end
 json.read notification.read

--- a/app/views/partials/_map.jbuilder
+++ b/app/views/partials/_map.jbuilder
@@ -2,6 +2,8 @@ json.id map.id
 json.owner do
   json.id map.user.id
   json.name map.user.name
+  json.image map.user.image_variants
+  json.image_url map.user.image_url
   json.profile_image_url map.user.thumbnail_url
 end
 json.name map.name
@@ -14,8 +16,10 @@ json.postable current_user.postable?(map)
 json.private map.private
 json.shared map.shared
 json.invitable map.invitable
-json.thumbnail_url map.image_url.present? ? map.thumbnail_url : ''
-json.thumbnail_url_400 map.image_url.present? ? map.thumbnail_url('400x400') : ''
-json.thumbnail_url_800 map.image_url.present? ? map.thumbnail_url('800x800') : ''
+json.image map.image_variants
+json.image_url map.image_url
+json.thumbnail_url map.thumbnail_url
+json.thumbnail_url_400 map.thumbnail_url('400x400')
+json.thumbnail_url_800 map.thumbnail_url('800x800')
 json.created_at map.created_at
 json.updated_at map.updated_at

--- a/app/views/partials/_public_user.jbuilder
+++ b/app/views/partials/_public_user.jbuilder
@@ -2,7 +2,8 @@ json.id user.id
 json.uid user.uid
 json.name user.name
 json.biography user.biography
-json.image_url user.image_path
+json.image user.image_variants
+json.image_url user.image_url
 json.thumbnail_url user.thumbnail_url
 json.thumbnail_url_400 user.thumbnail_url('400x400')
 json.thumbnail_url_800 user.thumbnail_url('800x800')

--- a/app/views/partials/_review.jbuilder
+++ b/app/views/partials/_review.jbuilder
@@ -5,6 +5,8 @@ json.longitude review.lng
 json.author do
   json.id review.user.id
   json.name review.user.name
+  json.image review.user.image_variants
+  json.image_url review.user.image_url
   json.profile_image_url review.user.thumbnail_url
 end
 json.comment review.comment
@@ -14,17 +16,24 @@ json.comments review.comments do |comment|
   json.author do
     json.id comment.user.id
     json.name comment.user.name
+    json.image comment.user.image_variants
+    json.image_url comment.user.image_url
     json.profile_image_url comment.user.thumbnail_url
   end
   json.body comment.body
   json.created_at comment.created_at
 end
 json.images review.images do |image|
+  variants = image.variants
   json.id image.id
   json.url image.url
   json.thumbnail_url image.thumbnail_url
   json.thumbnail_url_400 image.thumbnail_url('400x400')
   json.thumbnail_url_800 image.thumbnail_url('800x800')
+  json.avatar variants[:avatar]
+  json.card variants[:card]
+  json.hero variants[:hero]
+  json.ogp variants[:ogp]
 end
 json.map do
   json.id review.map_id

--- a/app/views/partials/_user.jbuilder
+++ b/app/views/partials/_user.jbuilder
@@ -2,7 +2,8 @@ json.id user.id
 json.uid user.uid
 json.name user.name
 json.biography user.biography
-json.image_url user.image_path
+json.image user.image_variants
+json.image_url user.image_url
 json.thumbnail_url user.thumbnail_url
 json.thumbnail_url_400 user.thumbnail_url('400x400')
 json.thumbnail_url_800 user.thumbnail_url('800x800')

--- a/app/views/partials/guest/_collaborator.jbuilder
+++ b/app/views/partials/guest/_collaborator.jbuilder
@@ -1,5 +1,7 @@
 json.id collaborator.id
 json.name collaborator.name
+json.image collaborator.image_variants
+json.image_url collaborator.image_url
 json.profile_image_url collaborator.thumbnail_url
 json.created_at collaborator.created_at
 json.updated_at collaborator.updated_at

--- a/app/views/partials/guest/_map.jbuilder
+++ b/app/views/partials/guest/_map.jbuilder
@@ -2,6 +2,8 @@ json.id map.id
 json.owner do
   json.id map.user.id
   json.name map.user.name
+  json.image map.user.image_variants
+  json.image_url map.user.image_url
   json.profile_image_url map.user.thumbnail_url
 end
 json.name map.name
@@ -14,8 +16,10 @@ json.postable false
 json.private map.private
 json.shared map.shared
 json.invitable map.invitable
-json.thumbnail_url map.image_url.present? ? map.thumbnail_url : ''
-json.thumbnail_url_400 map.image_url.present? ? map.thumbnail_url('400x400') : ''
-json.thumbnail_url_800 map.image_url.present? ? map.thumbnail_url('800x800') : ''
+json.image map.image_variants
+json.image_url map.image_url
+json.thumbnail_url map.thumbnail_url
+json.thumbnail_url_400 map.thumbnail_url('400x400')
+json.thumbnail_url_800 map.thumbnail_url('800x800')
 json.created_at map.created_at
 json.updated_at map.updated_at

--- a/app/views/partials/guest/_review.jbuilder
+++ b/app/views/partials/guest/_review.jbuilder
@@ -5,6 +5,8 @@ json.longitude review.lng
 json.author do
   json.id review.user.id
   json.name review.user.name
+  json.image review.user.image_variants
+  json.image_url review.user.image_url
   json.profile_image_url review.user.thumbnail_url
 end
 json.comment review.comment
@@ -14,17 +16,24 @@ json.comments review.comments do |comment|
   json.author do
     json.id comment.user.id
     json.name comment.user.name
+    json.image comment.user.image_variants
+    json.image_url comment.user.image_url
     json.profile_image_url comment.user.thumbnail_url
   end
   json.body comment.body
   json.created_at comment.created_at
 end
 json.images review.images do |image|
+  variants = image.variants
   json.id image.id
   json.url image.url
   json.thumbnail_url image.thumbnail_url
   json.thumbnail_url_400 image.thumbnail_url('400x400')
   json.thumbnail_url_800 image.thumbnail_url('800x800')
+  json.avatar variants[:avatar]
+  json.card variants[:card]
+  json.hero variants[:hero]
+  json.ogp variants[:ogp]
 end
 json.map do
   json.id review.map_id

--- a/app/views/partials/guest/_user.jbuilder
+++ b/app/views/partials/guest/_user.jbuilder
@@ -1,7 +1,8 @@
 json.id user.id
 json.name user.name
 json.biography user.biography
-json.image_url user.image_path
+json.image user.image_variants
+json.image_url user.image_url
 json.thumbnail_url user.thumbnail_url
 json.thumbnail_url_400 user.thumbnail_url('400x400')
 json.thumbnail_url_800 user.thumbnail_url('800x800')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   end
   resources :inappropriate_contents, only: [:create]
   resources :notifications, only: %i[index update]
+  resources :images, only: [:create]
 
   namespace :guest do
     resources :maps, only: %i[index show] do

--- a/db/migrate/20260520063537_add_polymorphic_to_images.rb
+++ b/db/migrate/20260520063537_add_polymorphic_to_images.rb
@@ -1,0 +1,7 @@
+class AddPolymorphicToImages < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :images, :user, foreign_key: true, null: true
+    add_reference :images, :imageable, polymorphic: true, null: true
+    change_column_null :images, :review_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_14_051127) do
+ActiveRecord::Schema.define(version: 2026_05_20_063537) do
 
   create_table "comments", charset: "utf8mb4", force: :cascade do |t|
     t.string "commentable_type", null: false
@@ -48,12 +48,17 @@ ActiveRecord::Schema.define(version: 2023_12_14_051127) do
   end
 
   create_table "images", charset: "utf8mb4", force: :cascade do |t|
-    t.bigint "review_id", null: false
+    t.bigint "review_id"
     t.string "url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.string "imageable_type"
+    t.bigint "imageable_id"
+    t.index ["imageable_type", "imageable_id"], name: "index_images_on_imageable"
     t.index ["review_id"], name: "index_images_on_review_id"
     t.index ["url"], name: "index_images_on_url", unique: true
+    t.index ["user_id"], name: "index_images_on_user_id"
   end
 
   create_table "inappropriate_contents", charset: "utf8mb4", force: :cascade do |t|
@@ -174,6 +179,7 @@ ActiveRecord::Schema.define(version: 2023_12_14_051127) do
   end
 
   add_foreign_key "images", "reviews"
+  add_foreign_key "images", "users"
   add_foreign_key "maps", "users"
   add_foreign_key "push_notifications", "users"
   add_foreign_key "reviews", "maps"

--- a/lib/tasks/backfill_polymorphic_images.rb
+++ b/lib/tasks/backfill_polymorphic_images.rb
@@ -1,0 +1,67 @@
+# bin/rails runner lib/tasks/backfill_polymorphic_images.rb
+#
+# Populates the polymorphic columns added by 20260520063537_add_polymorphic_to_images.
+# Run once after the migration; the follow-up migration that tightens NOT NULL and
+# drops the legacy columns assumes this task has completed.
+
+# Re-enable deprecated columns ignored at the model level so this task can read them.
+[User, Map, Image].each do |model|
+  model.ignored_columns = []
+  model.reset_column_information
+end
+
+rewired = 0
+Image.where(imageable_id: nil).where.not(review_id: nil).find_each do |image|
+  review = Review.find_by(id: image.review_id)
+  next unless review
+
+  image.update_columns(
+    user_id: review.user_id,
+    imageable_id: review.id,
+    imageable_type: 'Review'
+  )
+  rewired += 1
+end
+
+skipped = 0
+
+user_avatars = 0
+User.where.not(image_path: [nil, '']).find_each do |user|
+  # The SQL filter only excludes NULL and empty strings; whitespace-only values
+  # reach here and would fail Image's url presence/format validation.
+  next if user.image_path.blank?
+  next if Image.exists?(url: user.image_path)
+
+  Image.create!(
+    user_id: user.id,
+    imageable_id: user.id,
+    imageable_type: 'User',
+    url: user.image_path
+  )
+  user_avatars += 1
+rescue ActiveRecord::RecordInvalid => e
+  Rails.logger.warn("Skipped user #{user.id} avatar backfill: #{e.message}")
+  skipped += 1
+end
+
+map_thumbnails = 0
+Map.where.not(image_url: [nil, '']).find_each do |map|
+  next if map.image_url.blank?
+  next if Image.exists?(url: map.image_url)
+
+  Image.create!(
+    user_id: map.user_id,
+    imageable_id: map.id,
+    imageable_type: 'Map',
+    url: map.image_url
+  )
+  map_thumbnails += 1
+rescue ActiveRecord::RecordInvalid => e
+  Rails.logger.warn("Skipped map #{map.id} thumbnail backfill: #{e.message}")
+  skipped += 1
+end
+
+summary = "Backfill complete: #{rewired} rewired, #{user_avatars} user avatars, " \
+          "#{map_thumbnails} map thumbnails, #{skipped} skipped"
+Rails.logger.info(summary)
+puts summary

--- a/lib/tasks/migrate_images_to_cloudflare.rb
+++ b/lib/tasks/migrate_images_to_cloudflare.rb
@@ -1,0 +1,23 @@
+# bin/rails runner lib/tasks/migrate_images_to_cloudflare.rb
+
+migrated = 0
+failed = 0
+
+Image.where.not('url LIKE ?', "%#{Cloudflare::Images::DELIVERY_HOST}%").find_each do |image|
+  new_url = Cloudflare::Images.new.upload_from_url(image.url)
+
+  if new_url.blank?
+    failed += 1
+    Rails.logger.error("Failed to migrate image #{image.id}: empty variant URL")
+    next
+  end
+
+  image.update_columns(url: new_url, updated_at: Time.current)
+  migrated += 1
+  Rails.logger.info("Migrated image #{image.id}: -> #{new_url}")
+rescue StandardError => e
+  failed += 1
+  Rails.logger.error("Failed to migrate image #{image.id}: #{e.message}")
+end
+
+Rails.logger.info("Migration complete: #{migrated} migrated, #{failed} failed")

--- a/run/dev/api/base.yaml
+++ b/run/dev/api/base.yaml
@@ -41,6 +41,8 @@ spec:
           env:
             - name: RAILS_ENV
               value: production
+            - name: APP_ENV
+              value: development
             - name: OTEL_SERVICE_NAME
               value: qoodish-api
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -63,6 +65,15 @@ spec:
               value: https://storage.googleapis.com
             - name: CLOUD_STORAGE_BUCKET_NAME
               value: qoodish-dev.appspot.com
+            - name: CLOUDFLARE_ACCOUNT_ID
+              value: 9671c836ad132f87d892b12ccd1809e0
+            - name: CLOUDFLARE_IMAGES_ACCOUNT_HASH
+              value: ij3ygWRDWuATHKgheHKS5A
+            - name: CLOUDFLARE_IMAGES_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: QOODISH_API_CLOUDFLARE_IMAGES_API_TOKEN
+                  key: latest
             - name: GOOGLE_PROJECT_ID
               value: qoodish-dev
             - name: GOOGLE_ACCOUNT_TYPE

--- a/run/dev/runner/base.yaml
+++ b/run/dev/runner/base.yaml
@@ -24,6 +24,8 @@ spec:
               env:
                 - name: RAILS_ENV
                   value: production
+                - name: APP_ENV
+                  value: development
                 - name: GOOGLE_CLIENT_EMAIL
                   value: dev-qoodish-api@qoodish-common.iam.gserviceaccount.com
                 - name: GOOGLE_CLIENT_ID
@@ -42,6 +44,15 @@ spec:
                   value: qoodish-dev
                 - name: GOOGLE_ACCOUNT_TYPE
                   value: service_account
+                - name: CLOUDFLARE_ACCOUNT_ID
+                  value: 9671c836ad132f87d892b12ccd1809e0
+                - name: CLOUDFLARE_IMAGES_ACCOUNT_HASH
+                  value: ij3ygWRDWuATHKgheHKS5A
+                - name: CLOUDFLARE_IMAGES_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: QOODISH_API_CLOUDFLARE_IMAGES_API_TOKEN
+                      key: latest
                 - name: GOOGLE_API_KEY_SERVER
                   valueFrom:
                     secretKeyRef:

--- a/run/prod/api/base.yaml
+++ b/run/prod/api/base.yaml
@@ -44,6 +44,8 @@ spec:
           env:
             - name: RAILS_ENV
               value: production
+            - name: APP_ENV
+              value: production
             - name: OTEL_SERVICE_NAME
               value: qoodish-api
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -62,6 +64,15 @@ spec:
               value: https://storage.googleapis.com
             - name: CLOUD_STORAGE_BUCKET_NAME
               value: qoodish.appspot.com
+            - name: CLOUDFLARE_ACCOUNT_ID
+              value: 9671c836ad132f87d892b12ccd1809e0
+            - name: CLOUDFLARE_IMAGES_ACCOUNT_HASH
+              value: ij3ygWRDWuATHKgheHKS5A
+            - name: CLOUDFLARE_IMAGES_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: QOODISH_API_CLOUDFLARE_IMAGES_API_TOKEN
+                  key: latest
             - name: GOOGLE_PROJECT_ID
               value: qoodish
             - name: GOOGLE_ACCOUNT_TYPE

--- a/run/prod/runner/base.yaml
+++ b/run/prod/runner/base.yaml
@@ -24,6 +24,8 @@ spec:
               env:
                 - name: RAILS_ENV
                   value: production
+                - name: APP_ENV
+                  value: production
                 - name: GOOGLE_CLIENT_EMAIL
                   value: prod-qoodish-api@qoodish-common.iam.gserviceaccount.com
                 - name: GOOGLE_CLIENT_ID
@@ -42,6 +44,15 @@ spec:
                   value: qoodish
                 - name: GOOGLE_ACCOUNT_TYPE
                   value: service_account
+                - name: CLOUDFLARE_ACCOUNT_ID
+                  value: 9671c836ad132f87d892b12ccd1809e0
+                - name: CLOUDFLARE_IMAGES_ACCOUNT_HASH
+                  value: ij3ygWRDWuATHKgheHKS5A
+                - name: CLOUDFLARE_IMAGES_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: QOODISH_API_CLOUDFLARE_IMAGES_API_TOKEN
+                      key: latest
                 - name: GOOGLE_API_KEY_SERVER
                   valueFrom:
                     secretKeyRef:

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class ImagesControllerTest < ActionDispatch::IntegrationTest
+  test 'create without authentication should return unauthorized' do
+    post '/images'
+    assert_response :unauthorized
+  end
+
+  test 'create with authentication should return upload URL and image id' do
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        post '/images', headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    assert res['id'].present?
+    assert_equal 'https://upload.example.com/qoodish/test/mock-cf-id', res['upload_url']
+
+    image = Image.find(res['id'])
+    assert_equal users(:me).id, image.user_id
+    assert_nil image.imageable_id
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/test/mock-cf-id/public', image.url
+  end
+end

--- a/test/controllers/maps_controller_test.rb
+++ b/test/controllers/maps_controller_test.rb
@@ -32,4 +32,39 @@ class MapsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal res['id'], maps(:private_following).id
   end
+
+  test 'update accepts legacy image_url and converts to image_ids' do
+    map = maps(:public_one)
+    url = 'https://storage.googleapis.com/qoodish.appspot.com/maps/map-legacy.jpg'
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/maps/#{map.id}",
+            params: { image_url: url },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    images = map.reload.images
+    assert_equal [url], images.map(&:url)
+    assert_equal [users(:me).id], images.map(&:user_id).uniq
+  end
+
+  test 'update silently drops legacy image_url already owned by another user' do
+    foreign_url = 'https://imagedelivery.net/mockhash/foreign-map/public'
+    users(:you).owned_images.create!(url: foreign_url)
+    map = maps(:public_one)
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/maps/#{map.id}",
+            params: { image_url: foreign_url },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    assert_empty map.reload.images
+  end
 end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,7 +1,60 @@
 require 'test_helper'
 
 class NotificationsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'index renders successfully when notifiable is a Review' do
+    review = reviews(:public_one)
+    Notification.create!(
+      notifiable: review,
+      notifier: users(:you),
+      recipient: users(:me),
+      key: 'liked'
+    )
+
+    stub_google_auth(users(:me)) do
+      get '/notifications', headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+    body = JSON.parse(@response.body)
+    notification = body.find { |n| n['notifiable']['id'] == review.id && n['notifiable']['type'] == 'review' }
+    assert notification
+    # image_variants returns a hash when the notifiable has images, else null.
+    assert notification['notifiable'].key?('image')
+  end
+
+  test 'index renders successfully when notifiable is a Comment' do
+    comment = comments(:one)
+    Notification.create!(
+      notifiable: comment,
+      notifier: users(:you),
+      recipient: users(:me),
+      key: 'liked'
+    )
+
+    stub_google_auth(users(:me)) do
+      get '/notifications', headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+    body = JSON.parse(@response.body)
+    notification = body.find { |n| n['notifiable']['id'] == comment.id && n['notifiable']['type'] == 'comment' }
+    assert notification
+    assert notification['notifiable'].key?('image')
+  end
+
+  test 'index renders successfully when notifiable is a Map' do
+    map = maps(:private)
+    Notification.create!(
+      notifiable: map,
+      notifier: users(:you),
+      recipient: users(:me),
+      key: 'followed'
+    )
+
+    stub_google_auth(users(:me)) do
+      get '/notifications', headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+  end
 end

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -15,4 +15,96 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
                  review['map']['id'] == maps(:private_unfollowing).id || review['map']['id'] == maps(:public_unfollowing).id
                end)
   end
+
+  test 'update with image_ids attaches owned images' do
+    image_a = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/review-update-a/public'
+    )
+    image_b = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/review-update-b/public'
+    )
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/reviews/#{reviews(:public_one).id}",
+            params: { name: 'updated', image_ids: [image_a.id, image_b.id] },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    assert_equal [image_a.id, image_b.id].sort,
+                 reviews(:public_one).reload.image_ids.sort
+  end
+
+  test 'update with image_ids destroys removed images' do
+    review = reviews(:public_one)
+    removed = images(:two)
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/reviews/#{review.id}",
+            params: { image_ids: [images(:one).id] },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    assert_equal [images(:one).id], review.reload.image_ids
+    assert_nil Image.find_by(id: removed.id)
+  end
+
+  test 'update rejects image_ids that belong to another user' do
+    foreign_image = users(:you).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/review-foreign/public'
+    )
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/reviews/#{reviews(:public_one).id}",
+            params: { image_ids: [foreign_image.id] },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :unprocessable_content
+    assert_equal [images(:one).id, images(:two).id].sort,
+                 reviews(:public_one).reload.image_ids.sort
+  end
+
+  test 'update accepts legacy images param and converts to image_ids' do
+    review = reviews(:public_one)
+    new_url = 'https://imagedelivery.net/mockhash/review-legacy/public'
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/reviews/#{review.id}",
+            params: { images: [{ url: new_url }] },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    images = review.reload.images
+    assert_equal [new_url], images.map(&:url)
+    assert_equal [users(:me).id], images.map(&:user_id).uniq
+  end
+
+  test 'update silently drops legacy images URL already owned by another user' do
+    foreign_url = 'https://imagedelivery.net/mockhash/foreign-review/public'
+    users(:you).owned_images.create!(url: foreign_url)
+    review = reviews(:public_one)
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/reviews/#{review.id}",
+            params: { images: [{ url: foreign_url }] },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    # The foreign-owned URL is dropped, so the review ends up with no images.
+    assert_empty review.reload.images
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -27,12 +27,45 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert res['push_notification'].blank?
   end
 
+  test 'update accepts legacy image_path and converts to image_ids' do
+    url = 'https://storage.googleapis.com/qoodish.appspot.com/profile/user-legacy.jpg'
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/users/#{users(:me).uid}",
+            params: { image_path: url },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    images = users(:me).reload.images
+    assert_equal [url], images.map(&:url)
+    assert_equal [users(:me).id], images.map(&:user_id).uniq
+  end
+
+  test 'update silently drops legacy image_path already owned by another user' do
+    foreign_url = 'https://imagedelivery.net/mockhash/foreign-user/public'
+    users(:you).owned_images.create!(url: foreign_url)
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/users/#{users(:me).uid}",
+            params: { image_path: foreign_url },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    assert_empty users(:me).reload.images
+  end
+
   test 'delete account should be success' do
     uid = users(:me).uid
 
     stub_google_auth(users(:me)) do
       stub_identity_platform do
-        stub_cloud_storage do
+        stub_cloudflare_images do
           delete "/users/#{uid}", headers: { 'Authorization': 'Bearer dummytoken' }
         end
       end

--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -1,7 +1,9 @@
 one:
-  review: public_one
-  url: https://example.com/1
+  user: me
+  imageable: public_one (Review)
+  url: https://imagedelivery.net/mockhash/image-one/public
 
 two:
-  review: public_one
-  url: https://example.com/2
+  user: me
+  imageable: public_one (Review)
+  url: https://imagedelivery.net/mockhash/image-two/public

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,10 +2,8 @@ me:
   name: watame
   email: watame@qoodish.com
   uid: 1234abcde
-  image_path: https://example.com/1
 
 you:
   name: okayu
   email: okayu@qoodish.com
   uid: 5678fghij
-  image_path: https://example.com/2

--- a/test/models/cloudflare/images_test.rb
+++ b/test/models/cloudflare/images_test.rb
@@ -1,0 +1,119 @@
+require 'test_helper'
+
+class Cloudflare::ImagesTest < ActiveSupport::TestCase
+  test 'extract_id returns the image id segment for an opaque delivery URL' do
+    url = 'https://imagedelivery.net/mockhash/abc123/public'
+    assert_equal 'abc123', Cloudflare::Images.extract_id(url)
+  end
+
+  test 'extract_id returns the service-scoped id for the standard custom-id delivery URL' do
+    url = 'https://imagedelivery.net/mockhash/qoodish/8a5e2b1c/public'
+    assert_equal 'qoodish/8a5e2b1c', Cloudflare::Images.extract_id(url)
+  end
+
+  test 'extract_id returns the full id for a legacy delivery URL with an env segment' do
+    url = 'https://imagedelivery.net/mockhash/qoodish/development/8a5e2b1c/public'
+    assert_equal 'qoodish/development/8a5e2b1c', Cloudflare::Images.extract_id(url)
+  end
+
+  test 'extract_id returns nil for non-Cloudflare delivery hosts' do
+    url = 'https://storage.googleapis.com/qoodish.appspot.com/images/foo.jpg'
+    assert_nil Cloudflare::Images.extract_id(url)
+  end
+
+  test 'variant_url replaces only the variant segment with the given variant name' do
+    url = 'https://imagedelivery.net/mockhash/qoodish/development/8a5e2b1c/public'
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/development/8a5e2b1c/card',
+                 Cloudflare::Images.variant_url(url, 'card')
+  end
+
+  test 'variant_url_for_legacy_size maps legacy thumbnail sizes to configured variants' do
+    url = 'https://imagedelivery.net/mockhash/qoodish/8a5e2b1c/public'
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/8a5e2b1c/avatar',
+                 Cloudflare::Images.variant_url_for_legacy_size(url, '200x200')
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/8a5e2b1c/card',
+                 Cloudflare::Images.variant_url_for_legacy_size(url, '400x400')
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/8a5e2b1c/hero',
+                 Cloudflare::Images.variant_url_for_legacy_size(url, '800x800')
+  end
+
+  test 'variant_url_for_legacy_size falls back to public for unmapped sizes' do
+    url = 'https://imagedelivery.net/mockhash/qoodish/8a5e2b1c/public'
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/8a5e2b1c/public',
+                 Cloudflare::Images.variant_url_for_legacy_size(url, '9999x9999')
+  end
+
+  test 'upload_from_url returns the canonical /public URL regardless of variants order' do
+    body = {
+      'success' => true,
+      'result' => {
+        'id' => 'qoodish/test/abc',
+        # Dashboard order is not guaranteed; place a non-public variant first
+        # to confirm the implementation builds the URL from id, not variants.first.
+        'variants' => [
+          'https://imagedelivery.net/mockhash/qoodish/test/abc/avatar',
+          'https://imagedelivery.net/mockhash/qoodish/test/abc/public'
+        ]
+      }
+    }.to_json
+
+    stubs = Faraday::Adapter::Test::Stubs.new
+    stubs.post(%r{/client/v4/accounts/.*/images/v1\z}) do
+      [200, { 'Content-Type' => 'application/json' }, body]
+    end
+
+    connection = build_multipart_connection(stubs)
+
+    with_env('CLOUDFLARE_IMAGES_ACCOUNT_HASH' => 'mockhash') do
+      cf = Cloudflare::Images.new
+      cf.instance_variable_set(:@multipart_faraday, connection)
+
+      assert_equal 'https://imagedelivery.net/mockhash/qoodish/test/abc/public',
+                   cf.upload_from_url('https://example.com/source.jpg')
+    end
+  end
+
+  test 'upload_from_url encodes the request as multipart/form-data' do
+    body = { 'success' => true, 'result' => { 'id' => 'qoodish/test/abc' } }.to_json
+
+    captured_content_type = nil
+    captured_body_class = nil
+
+    stubs = Faraday::Adapter::Test::Stubs.new
+    stubs.post(%r{/client/v4/accounts/.*/images/v1\z}) do |env|
+      captured_content_type = env.request_headers['Content-Type']
+      captured_body_class = env.body.class
+      [200, { 'Content-Type' => 'application/json' }, body]
+    end
+
+    connection = build_multipart_connection(stubs)
+
+    with_env('CLOUDFLARE_IMAGES_ACCOUNT_HASH' => 'mockhash') do
+      cf = Cloudflare::Images.new
+      cf.instance_variable_set(:@multipart_faraday, connection)
+      cf.upload_from_url('https://example.com/source.jpg')
+    end
+
+    assert_match %r{\Amultipart/form-data; boundary=}, captured_content_type
+    refute_equal Hash, captured_body_class
+  end
+
+  private
+
+  def build_multipart_connection(stubs)
+    Faraday.new do |f|
+      f.request :multipart
+      f.response :json
+      f.adapter :test, stubs
+    end
+  end
+
+  def with_env(overrides)
+    prior = overrides.transform_values { |_| nil }
+    overrides.each_key { |k| prior[k] = ENV[k] }
+    overrides.each { |k, v| ENV[k] = v }
+    yield
+  ensure
+    prior.each { |k, v| ENV[k] = v }
+  end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'image_variants delegates to commentable' do
+    comment = comments(:one)
+    assert_equal comment.commentable.image_variants, comment.image_variants
+  end
 end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,7 +1,111 @@
 require 'test_helper'
 
 class ImageTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'allows attaching an image to a Map owned by the uploader' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/own-map-image/public'
+    )
+
+    assert image.update(imageable: maps(:private))
+  end
+
+  test 'rejects attaching an image to a Map owned by another user' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/foreign-map-image/public'
+    )
+
+    refute image.update(imageable: maps(:private_unfollowing))
+    assert_includes image.errors[:user], I18n.t('errors.messages.invalid')
+  end
+
+  test 'rejects attaching an image to a Review owned by another user' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/foreign-review-image/public'
+    )
+
+    refute image.update(imageable: reviews(:private_you))
+    assert_includes image.errors[:user], I18n.t('errors.messages.invalid')
+  end
+
+  test 'rejects attaching an image to a different User as imageable' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/foreign-user-image/public'
+    )
+
+    refute image.update(imageable: users(:you))
+    assert_includes image.errors[:user], I18n.t('errors.messages.invalid')
+  end
+
+  test 'variants returns named variant URLs alongside the base url for a Cloudflare image' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/qoodish/test/abc/public'
+    )
+
+    variants = image.variants
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/test/abc/public', variants[:url]
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/test/abc/avatar', variants[:avatar]
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/test/abc/card', variants[:card]
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/test/abc/hero', variants[:hero]
+    assert_equal 'https://imagedelivery.net/mockhash/qoodish/test/abc/ogp', variants[:ogp]
+  end
+
+  test 'variants falls back to GCS-style paths for non-Cloudflare images' do
+    image = users(:me).owned_images.create!(
+      url: 'https://storage.googleapis.com/qoodish.appspot.com/images/foo.jpg'
+    )
+
+    variants = image.variants
+    assert_equal 'https://storage.googleapis.com/qoodish.appspot.com/images/foo.jpg', variants[:url]
+    assert_match %r{/images/thumbnails/foo_200x200\.jpg\z}, variants[:avatar]
+    assert_match %r{/images/thumbnails/foo_400x400\.jpg\z}, variants[:card]
+    assert_match %r{/images/thumbnails/foo_800x800\.jpg\z}, variants[:hero]
+    assert_equal 'https://storage.googleapis.com/qoodish.appspot.com/images/foo.jpg', variants[:ogp]
+  end
+
+  test 'thumbnail_url returns a configured variant URL for Cloudflare-hosted images' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/cf-id-variant/public'
+    )
+
+    assert_equal 'https://imagedelivery.net/mockhash/cf-id-variant/card',
+                 image.thumbnail_url('400x400')
+  end
+
+  test 'thumbnail_url falls back to GCS-style path for non-Cloudflare images' do
+    image = users(:me).owned_images.create!(
+      url: 'https://storage.googleapis.com/qoodish.appspot.com/images/foo.jpg'
+    )
+
+    assert_match %r{/images/thumbnails/foo_200x200\.jpg\z}, image.thumbnail_url
+  end
+
+  test 'destroy calls Cloudflare DELETE when url is in imagedelivery.net format' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/cf-id-abc/public'
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect(:delete, nil, ['cf-id-abc'])
+
+    Cloudflare::Images.stub :new, mock do
+      image.destroy!
+    end
+
+    mock.verify
+  end
+
+  test 'destroy does not call Cloudflare DELETE when url is not in imagedelivery.net format' do
+    image = users(:me).owned_images.create!(
+      url: 'https://storage.googleapis.com/qoodish.appspot.com/images/foo.jpg'
+    )
+
+    mock = Minitest::Mock.new
+    # delete should never be called; mock.verify would fail if it is
+
+    Cloudflare::Images.stub :new, mock do
+      image.destroy!
+    end
+
+    mock.verify
+  end
 end

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -1,7 +1,17 @@
 require 'test_helper'
 
 class ReviewTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'image_variants returns the first image variants hash' do
+    review = reviews(:public_one)
+    expected = review.images.first.variants
+
+    assert_equal expected, review.image_variants
+  end
+
+  test 'image_variants returns nil when the review has no images' do
+    review = reviews(:public_two)
+    assert_empty review.images
+
+    assert_nil review.image_variants
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,10 @@ require 'rails/test_help'
 
 require 'minitest/autorun'
 
+ENV['CLOUDFLARE_ACCOUNT_ID'] ||= 'test-account'
+ENV['CLOUDFLARE_IMAGES_ACCOUNT_HASH'] ||= 'mockhash'
+ENV['CLOUDFLARE_IMAGES_API_TOKEN'] ||= 'test-token'
+
 class ActiveSupport::TestCase
   fixtures :all
 
@@ -16,8 +20,8 @@ class ActiveSupport::TestCase
     IdentityPlatform.stub :new, IdentityPlatformMock.new, &block
   end
 
-  def stub_cloud_storage(&block)
-    Google::Cloud::Storage.stub :new, CloudStorageMock.new, &block
+  def stub_cloudflare_images(&block)
+    Cloudflare::Images.stub :new, CloudflareImagesMock.new, &block
   end
 
   class GoogleAuthMock
@@ -45,15 +49,17 @@ class ActiveSupport::TestCase
     def delete_account(_uid); end
   end
 
-  class CloudStorageMock
-    def bucket(_name)
-      BucketMock.new
+  class CloudflareImagesMock
+    MOCK_ID = 'qoodish/test/mock-cf-id'
+
+    def create_direct_upload
+      { id: MOCK_ID, upload_url: "https://upload.example.com/#{MOCK_ID}" }
     end
 
-    class BucketMock
-      def file(_path)
-        nil
-      end
+    def upload_from_url(_source_url)
+      "https://imagedelivery.net/mockhash/#{MOCK_ID}/public"
     end
+
+    def delete(_image_id); end
   end
 end


### PR DESCRIPTION
# Summary

Phase 1 of the GCS to Cloudflare Images migration. Introduces `POST /images` for Direct Creator Upload URL issuance, makes Image polymorphic so attaching, replacing, or removing an image on User, Map, or Review goes through a single model that cleans up the Cloudflare asset on destroy, and adds `image_url` to JSON responses while keeping the existing `thumbnail_url*` fields until Phase 3. The schema change is additive only; existing GCS data is moved into Image records by a backfill script (`bin/rails runner lib/tasks/backfill_polymorphic_images.rb`) run after deploy. Controllers accept the existing qoodish-web request shapes (legacy URL strings) alongside the new `image_ids` shape, so this PR can ship without a coordinated frontend release.

# Motivation

qoodish-web PR #1067 is replacing GCS-backed image hosting with Cloudflare Images. With Cloudflare Images, sizing is controlled by URL parameters instead of pre-generated thumbnails from Cloud Functions.

The backend must issue Direct Creator Upload URLs so the frontend uploads directly to Cloudflare. Promoting Image to a polymorphic resource also lets user avatars and map thumbnails participate in `Image#before_destroy`, so replacements no longer leave orphan files behind.

# Changes

- `POST /images` issues a Direct Creator Upload URL and returns `{ id, upload_url }` where `id` is the Image record id.
- `Cloudflare::Images` (PORO) wraps the Cloudflare API with a memoized Faraday client. `Faraday::Error` exceptions are caught at the application controller level via `rescue_from` and converted to 500 responses.
- Uploads carry a service-scoped custom ID (`qoodish/UUID`) and `{app: "qoodish", env: APP_ENV}` metadata, so the same Cloudflare account can host dev and prod (and future apps) without ID collisions. The custom ID is exposed in the delivery URL (`imagedelivery.net/<hash>/qoodish/<uuid>/<variant>`); environment is held only in metadata, which Cloudflare does not expose in delivery URLs and returns only via the API.
- Schema migration is additive only. `images.user_id` (nullable) and `images.imageable_id` / `images.imageable_type` are added, and `images.review_id` is relaxed to nullable. The legacy columns (`images.review_id`, `users.image_path`, `maps.image_url`) stay in the schema for the duration of Phase 1 and are listed in `ignored_columns` on Image, User, and Map so the application does not access them.
- Data backfill runs via `lib/tasks/backfill_polymorphic_images.rb` (`bin/rails runner`). It rewires existing Review images to the new polymorphic columns and creates Image rows for user avatars and map thumbnails currently stored in the legacy columns. Blank legacy values are skipped, and any row that still fails Image's URL validation is logged and counted, so a single malformed value does not abort the run.
- User, Map, and Review all declare `has_many :images, as: :imageable, dependent: :destroy`. User and Map cap the association at one image via `validates :images, length: { maximum: 1 }`; Review caps it at `MAX_IMAGE_COUNT_PER_REVIEW` (4). Using a `validates :images, length:` rule rather than a `has_one` association allows the cap to change without a schema change.
- Resource controllers pass `image_ids` directly to `update!` / `create!` for all three owners. ActiveRecord's `image_ids=` writer destroys displaced records via `dependent: :destroy` and attaches new ones inside the parent's transaction. Each destroy fires `Image#before_destroy`, which attempts to delete the Cloudflare asset and logs a warning on failure. A validation on Image rejects assignments where the uploader does not match the imageable's owner; authorization is enforced at the model layer rather than in each controller.
- For backward compatibility, controllers also accept the legacy request shapes (`image_path: "https://..."` on `PUT /users/:id`, `image_url: "https://..."` on `PUT /maps/:id`, `images: [{ url: "https://..." }]` on review create/update) and translate them into `image_ids` by finding or creating an Image with that URL owned by the current user. Because `Image.url` is globally unique, `find_or_create_by!` returns the existing row for a URL another user already owns; the controller then drops it rather than attaching a foreign-owned image. The legacy parameters and translation layer are removed in Phase 3 alongside the columns they backed.
- `thumbnail_url`, `thumbnail_url_400`, and `thumbnail_url_800` rewrite `imagedelivery.net`-hosted URLs to configured named variants via `Cloudflare::Images::LEGACY_SIZE_TO_VARIANT` (`200x200` → `avatar`, `400x400` → `card`, `800x800` → `hero`), so the `thumbnail_url_400` / `thumbnail_url_800` fields keep returning distinct URLs after the GCS-to-Cloudflare migration. All four named variants (`avatar`, `card`, `hero`, `ogp`) must be pre-configured in the Cloudflare Images dashboard.
- jbuilder responses gain `image_url` and a new `image` field carrying the qoodish-web `ImageVariants` shape (`{ url, avatar, card, hero, ogp }`, or `null` when the imageable has no image). Each entry in review `images[]` is extended with the same `avatar`, `card`, `hero`, and `ogp` URLs alongside its `id` and `url`. The variant names are enumerated in `Cloudflare::Images::NAMED_VARIANTS` (`avatar`, `card`, `hero`, `ogp`); the pixel sizes (avatar 80x80, card 400x400, hero 800x800, ogp 1200x630) are configured in the Cloudflare Images dashboard, not in the backend. The legacy `thumbnail_url`, `thumbnail_url_400`, `thumbnail_url_800`, and `profile_image_url` (a serialized alias for `thumbnail_url`) fields remain until Phase 3 for frontend compatibility.
- Cloud Run manifests (both the API service and the `qoodish-runner` Job) set `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_IMAGES_ACCOUNT_HASH` as plain env values. The account ID is a tenant identifier used by server-side API calls, and the account hash appears in every `imagedelivery.net` delivery URL — neither is a credential. `CLOUDFLARE_IMAGES_API_TOKEN` is pulled from Secret Manager (`QOODISH_API_CLOUDFLARE_IMAGES_API_TOKEN`). Both prod and dev manifests point at the same Cloudflare account; `APP_ENV` is set per manifest (`production` vs `development`) so the `env` metadata above can distinguish them even though `RAILS_ENV` is `production` in both. `CLOUD_STORAGE_*` and `GOOGLE_PRIVATE_KEY` remain; Phase 3 removes them.
- Phase 2 GCS-to-Cloudflare task (`lib/tasks/migrate_images_to_cloudflare.rb`) uses Cloudflare's URL-based upload (`Cloudflare::Images#upload_from_url`) so source images do not transit the backend during migration.

# Coordination with the frontend

This PR is backward compatible: the current qoodish-web release continues to function unchanged because the controllers translate the existing request shapes into `image_ids`. qoodish-web PR #1067 can be released independently, and will start exercising the new endpoints when it ships:

1. The upload endpoint moves from the previous client-side GCS flow to `POST /api/v1/images` (`ALLOWED_AUTH_POST_PATTERNS` needs the new path).
2. Resource update calls switch to `image_ids: [id]` for User, Map, and Review using the Image record id returned from `POST /images`.

# Rollout

This rollout sequence assumes the existing Cloud Run setup (`run/prod/api/base.yaml` pins traffic to the revision tagged `stable`; `.github/workflows/prod.yaml` deploys new revisions and assigns a per-release tag to `LATEST` but does not touch `stable`). The `stable` tag must be moved manually to promote a new revision. Each step keeps the running production code consistent with the schema state at all times.

1. **Deploy backend.** Push a release tag to run `.github/workflows/prod.yaml`, which builds the image and deploys a new API revision plus the `qoodish-runner` job. The `stable` tag still points at the prior revision, so production traffic continues to serve the prior code. Then, via the runner job:
   - `bin/rails db:migrate` — additive migration adds the polymorphic columns and relaxes `images.review_id` to nullable.
   - `bin/rails runner lib/tasks/backfill_polymorphic_images.rb` — populates `images.user_id`, `images.imageable_*`, and creates Image rows for the existing `users.image_path` and `maps.image_url` values.
   - Move the `stable` traffic tag to the new revision (`gcloud beta run services update-traffic qoodish-api --update-tags=stable=REVISION ...`; `--update-tags` preserves the per-release `LATEST` tags the workflow set, whereas `--set-tags` would replace them). The new revision starts serving with fully populated polymorphic data.
2. **Release qoodish-web PR #1067.** Old and new frontend clients work side by side: legacy URL-based shapes hit the translation layer, while the new client uses the `image_ids` shape directly.
3. **Run Cloudflare migration.** Execute `bin/rails runner lib/tasks/migrate_images_to_cloudflare.rb` (via the runner job) once the frontend cutover is complete. The task re-hosts every non-Cloudflare Image on `imagedelivery.net` via URL-based upload, so the source images do not transit the backend.
4. **Ship the Phase 3 follow-up PR.** It tightens `images.user_id` to NOT NULL, drops the legacy columns (`images.review_id`, `users.image_path`, `maps.image_url`), removes the `ignored_columns` entries and the translation-layer private methods in the controllers, drops the legacy `thumbnail_url*` jbuilder fields and helper methods, and removes the `google-cloud-storage` gem.

Rollback for step 1 is to move the `stable` tag back to the previous revision; the legacy columns are still populated until Phase 3, so the previous code continues to function on the same database.

# Testing

Reviewers should run `bin/rails db:migrate && bin/rails test`, then verify both flows manually:

- **Legacy shape**: `PUT /users/:id` with `image_path: "https://..."` (or the analogous payload on Maps/Reviews) — confirm the response exposes the URL in `image_url` and the `thumbnail_url*` fields.
- **New shape**: `POST /images` to get a Direct Upload URL, upload to Cloudflare, then `PUT` the resource with `image_ids: [id]` — confirm `image_url` is an `imagedelivery.net` URL containing the `qoodish/...` prefix, `thumbnail_url_400` resolves to the same URL with its final segment replaced by `card` (per `LEGACY_SIZE_TO_VARIANT`), and the `image` field returns `{ url, avatar, card, hero, ogp }` where each value is the delivery URL with the corresponding variant name as its final segment.

🤖 Generated with [Claude Code](https://claude.ai/code)