### PR TITLE
fix: read legacy columns directly in backfill

### DIFF
--- a/lib/tasks/backfill_polymorphic_images.rb
+++ b/lib/tasks/backfill_polymorphic_images.rb
@@ -4,7 +4,10 @@
 # Run once after the migration; the follow-up migration that tightens NOT NULL and
 # drops the legacy columns assumes this task has completed.
 
-# Re-enable deprecated columns ignored at the model level so this task can read them.
+# Re-enable deprecated columns ignored at the model level so this task can read
+# them. Read the legacy columns via [] (e.g. map[:image_url]) rather than the
+# accessor: Map#image_url is redefined to read the new association and returns
+# '' before the Image rows exist, which would silently skip every map.
 [User, Map, Image].each do |model|
   model.ignored_columns = []
   model.reset_column_information
@@ -27,16 +30,17 @@ skipped = 0
 
 user_avatars = 0
 User.where.not(image_path: [nil, '']).find_each do |user|
+  legacy_url = user[:image_path]
   # The SQL filter only excludes NULL and empty strings; whitespace-only values
   # reach here and would fail Image's url presence/format validation.
-  next if user.image_path.blank?
-  next if Image.exists?(url: user.image_path)
+  next if legacy_url.blank?
+  next if Image.exists?(url: legacy_url)
 
   Image.create!(
     user_id: user.id,
     imageable_id: user.id,
     imageable_type: 'User',
-    url: user.image_path
+    url: legacy_url
   )
   user_avatars += 1
 rescue ActiveRecord::RecordInvalid => e
@@ -46,14 +50,15 @@ end
 
 map_thumbnails = 0
 Map.where.not(image_url: [nil, '']).find_each do |map|
-  next if map.image_url.blank?
-  next if Image.exists?(url: map.image_url)
+  legacy_url = map[:image_url]
+  next if legacy_url.blank?
+  next if Image.exists?(url: legacy_url)
 
   Image.create!(
     user_id: map.user_id,
     imageable_id: map.id,
     imageable_type: 'Map',
-    url: map.image_url
+    url: legacy_url
   )
   map_thumbnails += 1
 rescue ActiveRecord::RecordInvalid => e
@@ -64,4 +69,3 @@ end
 summary = "Backfill complete: #{rewired} rewired, #{user_avatars} user avatars, " \
           "#{map_thumbnails} map thumbnails, #{skipped} skipped"
 Rails.logger.info(summary)
-puts summary


### PR DESCRIPTION
# Summary

The polymorphic-image backfill skipped every map and created `0 map thumbnails`. This fixes the loop to read the legacy columns directly so map and user image rows are created as intended.

# Motivation

`Map#image_url` is redefined to read the new polymorphic `images` association and returns `''` until the Image rows exist. The backfill called `map.image_url` inside its loop, so the accessor shadowed the legacy `maps.image_url` column and the `blank?` guard dropped every map. The production run reported `2231 rewired, 391 user avatars, 0 map thumbnails, 0 skipped`. The SQL `where` clause reads the column directly, so map selection itself was correct — only the in-loop check failed.

# Changes

- Read the legacy columns via `[]` (`map[:image_url]`, `user[:image_path]`) inside the loops so they bypass the model accessors and see the raw column values. `users.image_path` worked before (no shadowing method) but is switched for consistency.
- Document the reason in the preamble comment.
- Remove the duplicate stdout completion log; `Rails.logger.info` already emits it.

# Testing

Re-running is safe: the task is idempotent (rewire targets are already 0, and user/map creation is guarded by `Image.exists?`). Re-running after this fix creates the missing map Image rows.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Armn3JToBz3D7WFjbDupGh)_