### PR TITLE
fix: ignore dropped legacy image columns

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,4 +1,9 @@
 class Image < ApplicationRecord
+  # Tolerate the dropped legacy review_id column during the rollout window: an
+  # API instance that booted before the drop migration cached it and would
+  # otherwise emit it in INSERTs. Remove once all instances run the new schema.
+  self.ignored_columns += %w[review_id]
+
   belongs_to :user
   belongs_to :imageable, polymorphic: true, optional: true
 

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -1,4 +1,9 @@
 class Map < ApplicationRecord
+  # Tolerate the dropped legacy image_url column during the rollout window: an
+  # API instance that booted before the drop migration cached it and would
+  # otherwise emit it in INSERTs. Remove once all instances run the new schema.
+  self.ignored_columns += %w[image_url]
+
   belongs_to :user
   has_many :reviews, dependent: :destroy
   has_many :notifications, as: :notifiable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,9 @@
 class User < ApplicationRecord
+  # Tolerate the dropped legacy image_path column during the rollout window: an
+  # API instance that booted before the drop migration cached it and would
+  # otherwise emit it in INSERTs. Remove once all instances run the new schema.
+  self.ignored_columns += %w[image_path]
+
   has_many :devices, dependent: :destroy
   has_many :maps, dependent: :destroy
   has_many :reviews, dependent: :destroy


### PR DESCRIPTION
# Summary

Hotfix for a production error after the v2.0.0 rollout: image creation (and any write to `images`/`users`/`maps`) fails with `Trilogy::ProtocolError: 1054: Unknown column 'review_id' in 'field list'`. Re-adds `ignored_columns` for the three legacy columns that #540 dropped, so the models never reference them regardless of schema-cache state.

# Motivation

#540 dropped `images.review_id`, `users.image_path`, and `maps.image_url` **and** removed the `ignored_columns` that had hidden them. On the v2.0.0 release, the API revision started serving (and ActiveRecord cached the table columns, which still included `review_id`) before the drop migration ran. Once the column was gone, those instances kept emitting it in every `INSERT`, producing the `Unknown column` error.

Redeploying did not clear it (same-image redeploys reuse instances; the in-process schema cache survives). Re-introducing `ignored_columns` makes the models drop these columns from all generated SQL whatever the schema cache reports, which both restores the safe expand/contract intermediate state and forces a genuinely new revision on deploy.

# Changes

- `Image` — `self.ignored_columns += %w[review_id]`
- `User` — `self.ignored_columns += %w[image_path]`
- `Map` — `self.ignored_columns += %w[image_url]`

# Testing

- With the three columns re-added locally to simulate a stale schema, confirmed each model no longer reports the column (`column_names` excludes it) and that creating an `Image` succeeds without emitting `review_id`.
- `bin/rails test` → 105 runs, 0 failures. The single error (`NotificationTest#test_web_push_on_create`) pre-dates this change and stems from missing Google credentials in the local environment.

# Rollout

Temporary shim. After deploying and confirming every instance runs on the post-drop schema, remove the three `ignored_columns` lines in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaXJ6dqPZXVHXKcpqte3TZ)_