### PR TITLE
docs: add release and operations guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ This document provides essential context for Claude Code to understand the Qoodi
 - Business logic should primarily reside in models. For logic tied to a database table, use an ActiveRecord model. For logic not directly tied to a table, create a plain Ruby model (a class that does not inherit from `ApplicationRecord`).
 - All new API endpoints must be defined in `config/routes.rb`.
 - Ensure new features are covered by tests in the `test/` directory.
+- Write all text committed to the repository — PR descriptions, issue bodies, code comments, commit messages — in English.
 
 ## 5. Commit Message Generation Rules
 
@@ -55,3 +56,30 @@ When generating commit messages, please follow these rules:
 - Separate distinct paragraphs with a blank line.
 - Use the body to explain what and why vs. how.
 - Reference pull requests when applicable.
+
+## 6. Release & Operations Guidelines
+
+These rules cover database migrations, releases, and backward compatibility. Follow them to avoid breaking production or the `qoodish-web` frontend.
+
+### Migrations and Data Migration
+
+- Migration files in `db/migrate` must contain schema changes only. Do not write data-manipulation Ruby (model updates, backfills, record rewrites) inside a migration.
+- Perform all data migration through Rake tasks in `lib/tasks`, kept separate from schema migrations.
+
+### Running Tasks in Production
+
+- `db:migrate` and `rails runner` are executed on demand through the `qoodish-runner` Cloud Run Job, not automatically during deployment. Run schema migrations and data-migration Rake tasks by invoking this Job at the appropriate time.
+
+### Release Flow
+
+- Releases are driven by `release-please`. Merging the release PR into `master` tags a new version, which builds the image and deploys the new application revision with traffic shifted to it.
+
+### Dropping Columns
+
+- Removing a column takes two separate releases. First, ship a PR that only adds the column to `ignored_columns`, and release it. Only after that release is live, ship a second PR with the column-drop migration.
+- Never combine the `ignored_columns` addition and the column-drop migration in the same PR or the same release version.
+
+### Backward Compatibility with qoodish-web
+
+- Do not create a PR whose release would immediately break the behavior of the current `qoodish-web` version. Keep the API backward compatible, and plan a release sequence that includes the corresponding `qoodish-web` changes.
+- When a large change has ordering constraints across releases (or across the backend and frontend), document the release procedure in the PR description.


### PR DESCRIPTION
# Summary

Adds a "Release & Operations Guidelines" section to `CLAUDE.md` so Claude Code follows the project's migration, release, and backward-compatibility rules. Also moves the English-only requirement for repository text into the general code guidelines.

# Motivation

Recent changes broke production assumptions because these rules were not written down anywhere Claude Code reads. Capturing them in `CLAUDE.md` prevents the same mistakes: data logic leaking into migrations, column drops shipped in a single release, and breaking changes that immediately break the current `qoodish-web` version.

# Changes

- Restrict `db/migrate` files to schema changes only; run data migration as Rake tasks in `lib/tasks`.
- Document that `db:migrate` and `rails runner` run on demand via the `qoodish-runner` Cloud Run Job, and that releases flow through `release-please`.
- Require dropping a column across two releases, starting with an `ignored_columns`-only PR.
- Require keeping the API backward compatible with the current `qoodish-web` version and documenting release procedures in the PR description for changes with ordering constraints.
- Add a general rule to write all repository text in English.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnwiHKR7G1MmCUh5Hn8XBQ)_