### PR TITLE
feat: add bookmarks list endpoints

### DIFF
--- a/app/controllers/guest/users/bookmarks_controller.rb
+++ b/app/controllers/guest/users/bookmarks_controller.rb
@@ -1,0 +1,11 @@
+class Guest::Users::BookmarksController < ApplicationController
+  def index
+    # Bookmarks can only be created on public maps, so public_open is a
+    # defensive filter rather than a functional one.
+    @maps = Map
+            .public_open
+            .where(id: Bookmark.where(user_id: params[:user_id]).select(:map_id))
+            .preload(:images, user: :images)
+            .order(created_at: :desc)
+  end
+end

--- a/app/controllers/users/bookmarks_controller.rb
+++ b/app/controllers/users/bookmarks_controller.rb
@@ -1,0 +1,21 @@
+module Users
+  class BookmarksController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+      user = if params[:user_id] == current_user.uid
+               current_user
+             else
+               User.find_by!(id: params[:user_id])
+             end
+
+      # Bookmarks can only be created on public maps, so public_open is a
+      # defensive filter rather than a functional one.
+      @maps = Map
+              .public_open
+              .bookmarked_by(user)
+              .preload(:images, user: :images)
+              .order(created_at: :desc)
+    end
+  end
+end

--- a/app/controllers/users/maps_controller.rb
+++ b/app/controllers/users/maps_controller.rb
@@ -4,33 +4,18 @@ module Users
 
     def index
       @maps = if params[:user_id] == current_user.uid
-                if params[:following]
-                  current_user
-                    .bookmarked_maps
-                    .preload(:images, user: :images)
-                    .order(created_at: :desc)
-                else
-                  current_user
-                    .maps
-                    .preload(:images, user: :images)
-                    .order(created_at: :desc)
-                end
+                current_user
+                  .maps
+                  .preload(:images, user: :images)
+                  .order(created_at: :desc)
               else
                 user = User.find_by!(id: params[:user_id])
 
-                if params[:following]
-                  current_user
-                    .referenceable_maps
-                    .preload(:images, user: :images)
-                    .where(id: Map.bookmarked_by(user))
-                    .order(created_at: :desc)
-                else
-                  current_user
-                    .referenceable_maps
-                    .preload(:images, user: :images)
-                    .where(id: user.maps)
-                    .order(created_at: :desc)
-                end
+                current_user
+                  .referenceable_maps
+                  .preload(:images, user: :images)
+                  .where(user_id: user.id)
+                  .order(created_at: :desc)
               end
     end
   end

--- a/app/views/guest/users/bookmarks/index.jbuilder
+++ b/app/views/guest/users/bookmarks/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @maps, partial: 'partials/guest/map', as: :map

--- a/app/views/users/bookmarks/index.jbuilder
+++ b/app/views/users/bookmarks/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @maps, partial: 'partials/map', as: :map

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     scope module: :users do
       resources :maps, only: [:index]
       resources :reviews, only: [:index]
+      resources :bookmarks, only: [:index]
       resource :push_notification, only: [:update]
     end
   end
@@ -54,6 +55,7 @@ Rails.application.routes.draw do
       scope module: :users do
         resources :maps, only: [:index]
         resources :reviews, only: [:index]
+        resources :bookmarks, only: [:index]
       end
     end
   end

--- a/test/controllers/guest/users/bookmarks_controller_test.rb
+++ b/test/controllers/guest/users/bookmarks_controller_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class Guest::Users::BookmarksControllerTest < ActionDispatch::IntegrationTest
+  test 'list of user bookmarks returns public bookmarked maps' do
+    get "/guest/users/#{users(:you).id}/bookmarks"
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_includes res.map { |map| map['id'] }, maps(:public_one).id
+    assert(res.all? { |map| map['private'] == false })
+  end
+end

--- a/test/controllers/users/bookmarks_controller_test.rb
+++ b/test/controllers/users/bookmarks_controller_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Users::BookmarksControllerTest < ActionDispatch::IntegrationTest
+  test 'index without authentication should be unauthorized' do
+    get "/users/#{users(:me).uid}/bookmarks"
+
+    assert_response :unauthorized
+  end
+
+  test 'index returns own bookmarked maps' do
+    Bookmark.create!(map: maps(:public_unfollowing), user: users(:me))
+
+    stub_google_auth(users(:me)) do
+      get "/users/#{users(:me).uid}/bookmarks",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    ids = JSON.parse(@response.body).map { |map| map['id'] }
+
+    assert_equal [maps(:public_unfollowing).id], ids
+  end
+
+  test 'index returns another user bookmarked maps' do
+    stub_google_auth(users(:me)) do
+      get "/users/#{users(:you).id}/bookmarks",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    ids = JSON.parse(@response.body).map { |map| map['id'] }
+
+    assert_includes ids, maps(:public_one).id
+  end
+end


### PR DESCRIPTION
# Summary

Add endpoints that return the maps a user has bookmarked, for both authenticated and guest access, and remove the legacy `following` parameter that previously served this data through the maps index.

# Motivation

The Follow-to-Bookmark migration left the bookmark list without a dedicated endpoint. Listing a user's bookmarks relied on the `following` parameter of the user maps index, a leftover from the Follow model. Since user profiles are viewable without signing in, the bookmark list needs both an authenticated and a guest endpoint, matching the existing maps and reviews endpoints.

# Changes

- Add `GET /users/:user_id/bookmarks` (`Users::BookmarksController#index`), returning the public maps a user has bookmarked. Bookmarks can only be created on public maps, so the endpoint filters by `public_open` as a defensive measure.
- Add `GET /guest/users/:user_id/bookmarks` (`Guest::Users::BookmarksController#index`), returning the public maps a user has bookmarked, filtered by `public_open` for the same reason.
- Remove the `following` branch from `Users::MapsController#index`; the index now returns only the target user's own maps.

# Testing

- `bin/rails test` — all passing except a pre-existing `NotificationTest` failure caused by missing Google auth credentials in the local environment, unrelated to these changes.

# Release notes

The `following` parameter removal assumes `qoodish-web` no longer sends it. Confirmed no longer in use before removal.

🤖 Generated with [Claude Code](https://claude.ai/code)