### PR TITLE
feat: add journeys and chapters API

### DIFF
--- a/app/controllers/chapters_controller.rb
+++ b/app/controllers/chapters_controller.rb
@@ -1,0 +1,24 @@
+class ChaptersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @chapters = if params[:next_timestamp]
+                  Chapter
+                    .feed_for(current_user)
+                    .feed_before(params[:next_timestamp])
+                    .preload(:map, user: :images)
+                else
+                  Chapter
+                    .feed_for(current_user)
+                    .latest_feed
+                    .preload(:map, user: :images)
+                end
+  end
+
+  def show
+    @chapter = Chapter
+               .readable_by(current_user)
+               .preload(:map, user: :images)
+               .find_by!(id: params[:id])
+  end
+end

--- a/app/controllers/guest/chapters_controller.rb
+++ b/app/controllers/guest/chapters_controller.rb
@@ -1,0 +1,15 @@
+class Guest::ChaptersController < ApplicationController
+  def index
+    @chapters = Chapter
+                .public_open
+                .latest_feed
+                .preload(:map, user: :images)
+  end
+
+  def show
+    @chapter = Chapter
+               .public_open
+               .preload(:map, user: :images)
+               .find_by!(id: params[:id])
+  end
+end

--- a/app/controllers/guest/users/chapters_controller.rb
+++ b/app/controllers/guest/users/chapters_controller.rb
@@ -1,0 +1,9 @@
+class Guest::Users::ChaptersController < ApplicationController
+  def index
+    @chapters = Chapter
+                .public_open
+                .where(user_id: params[:user_id])
+                .preload(:map, user: :images)
+                .order(created_at: :desc)
+  end
+end

--- a/app/controllers/maps/chapters_controller.rb
+++ b/app/controllers/maps/chapters_controller.rb
@@ -1,0 +1,20 @@
+module Maps
+  class ChaptersController < ApplicationController
+    before_action :authenticate_user!
+
+    def create
+      map = current_user.referenceable_maps.find_by!(id: params[:map_id])
+      journey = current_user.journeys.find_by!(id: params[:journey_id]) if params[:journey_id].present?
+
+      @chapter = current_user.chapters.create!(chapter_params.merge(map: map, journey: journey))
+    end
+
+    private
+
+    def chapter_params
+      permitted = params.permit(:title)
+      permitted[:content] = params[:content].permit!.to_h if params[:content].is_a?(ActionController::Parameters)
+      permitted
+    end
+  end
+end

--- a/app/controllers/maps/journeys_controller.rb
+++ b/app/controllers/maps/journeys_controller.rb
@@ -1,0 +1,16 @@
+module Maps
+  class JourneysController < ApplicationController
+    before_action :authenticate_user!
+
+    def create
+      map = current_user.referenceable_maps.find_by!(id: params[:map_id])
+
+      @journey = current_user.journeys.create!(map: map)
+
+      ActiveRecord::Associations::Preloader.new(
+        records: [@journey],
+        associations: [:map, :milestones, :checkins, :chapter]
+      ).call
+    end
+  end
+end

--- a/app/controllers/me/chapters_controller.rb
+++ b/app/controllers/me/chapters_controller.rb
@@ -1,0 +1,33 @@
+module Me
+  class ChaptersController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+      @chapters = Chapter
+                  .where(user: current_user)
+                  .preload(:map, user: :images)
+                  .order(created_at: :desc)
+    end
+
+    def show
+      @chapter = current_user.chapters.find_by!(id: params[:id])
+    end
+
+    def update
+      @chapter = current_user.chapters.find_by!(id: params[:id])
+      @chapter.update!(chapter_params)
+    end
+
+    def destroy
+      current_user.chapters.find_by!(id: params[:id]).destroy!
+    end
+
+    private
+
+    def chapter_params
+      permitted = params.permit(:title, :status)
+      permitted[:content] = params[:content].permit!.to_h if params[:content].is_a?(ActionController::Parameters)
+      permitted
+    end
+  end
+end

--- a/app/controllers/me/journeys/checkins_controller.rb
+++ b/app/controllers/me/journeys/checkins_controller.rb
@@ -1,0 +1,20 @@
+module Me
+  module Journeys
+    class CheckinsController < ApplicationController
+      before_action :authenticate_user!
+
+      def create
+        journey = current_user.journeys.unfinished.find_by!(id: params[:journey_id])
+        review = current_user.referenceable_reviews.find_by!(id: params[:review_id])
+
+        @checkin = journey.checkins.create!(review: review)
+      end
+
+      def destroy
+        journey = current_user.journeys.unfinished.find_by!(id: params[:journey_id])
+
+        journey.checkins.find_by!(id: params[:id]).destroy!
+      end
+    end
+  end
+end

--- a/app/controllers/me/journeys/milestones_controller.rb
+++ b/app/controllers/me/journeys/milestones_controller.rb
@@ -1,0 +1,20 @@
+module Me
+  module Journeys
+    class MilestonesController < ApplicationController
+      before_action :authenticate_user!
+
+      def create
+        journey = current_user.journeys.unfinished.find_by!(id: params[:journey_id])
+        review = current_user.referenceable_reviews.find_by!(id: params[:review_id])
+
+        @milestone = journey.milestones.create!(review: review)
+      end
+
+      def destroy
+        journey = current_user.journeys.unfinished.find_by!(id: params[:journey_id])
+
+        journey.milestones.find_by!(id: params[:id]).destroy!
+      end
+    end
+  end
+end

--- a/app/controllers/me/journeys_controller.rb
+++ b/app/controllers/me/journeys_controller.rb
@@ -1,0 +1,46 @@
+module Me
+  class JourneysController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+      @journeys = current_user
+                  .journeys
+                  .preload(:map, :milestones, :checkins, :chapter)
+                  .order(created_at: :desc)
+    end
+
+    def show
+      @journey = current_user
+                 .journeys
+                 .preload(:map, :milestones, :checkins, :chapter)
+                 .find_by!(id: params[:id])
+    end
+
+    def destroy
+      current_user.journeys.find_by!(id: params[:id]).destroy!
+    end
+
+    def start
+      @journey = current_user.journeys.unfinished.find_by!(id: params[:id])
+      @journey.start!
+
+      preload_journey_for_serialization
+    end
+
+    def finish
+      @journey = current_user.journeys.unfinished.find_by!(id: params[:id])
+      @journey.finish!(encoded_path: params[:encoded_path])
+
+      preload_journey_for_serialization
+    end
+
+    private
+
+    def preload_journey_for_serialization
+      ActiveRecord::Associations::Preloader.new(
+        records: [@journey],
+        associations: [:map, :milestones, :checkins, :chapter]
+      ).call
+    end
+  end
+end

--- a/app/controllers/users/chapters_controller.rb
+++ b/app/controllers/users/chapters_controller.rb
@@ -1,0 +1,19 @@
+module Users
+  class ChaptersController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+      user = if params[:user_id] == current_user.uid
+               current_user
+             else
+               User.find_by!(id: params[:user_id])
+             end
+
+      @chapters = Chapter
+                  .referenceable_by(current_user)
+                  .where(user: user)
+                  .preload(:map, user: :images)
+                  .order(created_at: :desc)
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,7 +44,9 @@ class UsersController < ApplicationController
 
   def destroy
     current_user.reviews.preload(:images, :votes).load
-    current_user.maps.preload(:images, :coauthorships, :bookmarks, :coauthorship_invitations, :votes, reviews: [:images, :votes]).load
+    current_user.maps.preload(:images, :coauthorships, :bookmarks, :coauthorship_invitations, :votes,
+                              reviews: [:images, :votes]).load
+    current_user.journeys.preload(:milestones, :checkins).load
     current_user.destroy!
   end
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+MAX_CHAPTER_CONTENT_BYTESIZE = 1.megabyte
+CHAPTER_FEED_PER_PAGE = 12
+
+class Chapter < ApplicationRecord
+  belongs_to :user
+  belongs_to :map, optional: true
+  belongs_to :journey, optional: true
+
+  enum :status, { draft: 'draft', published: 'published' }, validate: true
+
+  validates :title,
+            presence: {
+              message: I18n.t('messages.api.chapter_title_required')
+            },
+            length: {
+              allow_blank: false,
+              maximum: 100,
+              message: I18n.t('messages.api.chapter_title_exceed')
+            }
+  validates :user_id,
+            presence: true
+  validates :map,
+            presence: true,
+            on: :create
+  validates :journey_id,
+            uniqueness: {
+              allow_nil: true,
+              message: I18n.t('messages.api.duplicate_chapter_for_journey')
+            }
+  validate :content_must_be_lexical_document
+  validate :journey_must_match_author_and_map
+
+  scope :referenceable_by, lambda { |user|
+    published.where(map_id: Map.referenceable_by(user))
+  }
+
+  scope :readable_by, lambda { |user|
+    referenceable_by(user).or(where(user_id: user.id))
+  }
+
+  scope :public_open, lambda {
+    published.where(map_id: Map.public_open)
+  }
+
+  scope :feed_for, lambda { |user|
+    published.where(map_id: Map.related_to(user))
+  }
+
+  scope :latest_feed, lambda {
+    order(created_at: :desc)
+      .limit(CHAPTER_FEED_PER_PAGE)
+  }
+
+  scope :feed_before, lambda { |created_at|
+    where('chapters.created_at < ?', Time.parse(created_at))
+      .order(created_at: :desc)
+      .limit(CHAPTER_FEED_PER_PAGE)
+  }
+
+  def content=(value)
+    super(value.is_a?(Hash) ? value.deep_stringify_keys : value)
+  end
+
+  private
+
+  def content_must_be_lexical_document
+    unless content.is_a?(Hash) && content['root'].is_a?(Hash)
+      errors.add(:content, I18n.t('messages.api.chapter_content_invalid'))
+      return
+    end
+
+    return if content.to_json.bytesize <= MAX_CHAPTER_CONTENT_BYTESIZE
+
+    errors.add(:content, I18n.t('messages.api.chapter_content_exceed'))
+  end
+
+  def journey_must_match_author_and_map
+    return if journey.blank?
+    return if journey.user_id == user_id && journey.map_id == map_id
+
+    errors.add(:journey_id, I18n.t('messages.api.chapter_journey_mismatch'))
+  end
+end

--- a/app/models/concerns/review_snapshot.rb
+++ b/app/models/concerns/review_snapshot.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Denormalizes the anchored review's name and coordinates at creation so the
+# record stays renderable after the review changes or is removed.
+module ReviewSnapshot
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :review, optional: true
+
+    before_validation :snapshot_review_attributes, on: :create
+
+    validates :review,
+              presence: true,
+              on: :create
+    validates :name,
+              presence: true
+    validates :latitude,
+              presence: true
+    validates :longitude,
+              presence: true
+    validate :review_must_be_on_journey_map, on: :create
+  end
+
+  def lat
+    latitude.to_f
+  end
+
+  def lng
+    longitude.to_f
+  end
+
+  private
+
+  def snapshot_review_attributes
+    return if review.blank?
+
+    self.name = review.name
+    self.latitude = review.latitude
+    self.longitude = review.longitude
+  end
+
+  def review_must_be_on_journey_map
+    return if journey.blank? || review.blank?
+    return if review.map_id == journey.map_id
+
+    errors.add(:review_id, I18n.t('messages.api.review_not_on_journey_map'))
+  end
+end

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+MAX_ENCODED_PATH_LENGTH = 1_000_000
+
+class Journey < ApplicationRecord
+  belongs_to :user
+  belongs_to :map, optional: true
+  has_many :milestones, -> { order(:position) }, dependent: :destroy, inverse_of: :journey
+  has_many :checkins,
+           -> { order(:id) },
+           class_name: 'JourneyCheckin',
+           dependent: :destroy,
+           inverse_of: :journey
+  has_one :chapter, dependent: :nullify
+
+  validates :user_id,
+            presence: true
+  validates :map,
+            presence: true,
+            on: :create
+  validates :encoded_path,
+            length: {
+              maximum: MAX_ENCODED_PATH_LENGTH,
+              message: I18n.t('messages.api.journey_encoded_path_exceed')
+            }
+  validates :map_id,
+            uniqueness: {
+              scope: :user_id,
+              conditions: -> { unfinished },
+              message: I18n.t('messages.api.duplicate_unfinished_journey')
+            },
+            on: :create
+  validate :encoded_path_only_while_in_progress, if: :encoded_path_changed?
+
+  scope :unfinished, lambda {
+    where(finished_at: nil)
+  }
+
+  def started?
+    started_at.present?
+  end
+
+  def finished?
+    finished_at.present?
+  end
+
+  def in_progress?
+    started? && !finished?
+  end
+
+  def start!
+    raise Exceptions::Conflict, I18n.t('messages.api.journey_already_started') if started?
+
+    update!(started_at: Time.current)
+  end
+
+  def finish!(encoded_path: nil)
+    raise Exceptions::Conflict, I18n.t('messages.api.journey_not_started') unless started?
+    raise Exceptions::Conflict, I18n.t('messages.api.journey_already_finished') if finished?
+
+    attributes = { finished_at: Time.current }
+    attributes[:encoded_path] = encoded_path if encoded_path.present?
+    update!(attributes)
+  end
+
+  private
+
+  # The trail is submitted together with the finish stamp, so this checks the
+  # persisted state (finished_at_was) rather than in_progress?, which would
+  # already read the finished_at being set in the same save.
+  def encoded_path_only_while_in_progress
+    return if encoded_path.blank?
+    return if started? && finished_at_was.nil?
+
+    errors.add(:encoded_path, I18n.t('messages.api.journey_not_in_progress'))
+  end
+end

--- a/app/models/journey_checkin.rb
+++ b/app/models/journey_checkin.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class JourneyCheckin < ApplicationRecord
+  include ReviewSnapshot
+
+  belongs_to :journey
+
+  validates :review_id,
+            uniqueness: {
+              scope: :journey_id,
+              message: I18n.t('messages.api.duplicate_checkin')
+            }
+  validate :journey_must_be_in_progress, on: :create
+
+  private
+
+  def journey_must_be_in_progress
+    return if journey.blank?
+    return if journey.in_progress?
+
+    errors.add(:base, I18n.t('messages.api.journey_not_in_progress'))
+  end
+end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -14,6 +14,8 @@ class Map < ApplicationRecord
   has_many :votes, as: :votable, dependent: :destroy
   has_many :voters, through: :votes, source: :voter, source_type: User.name
   has_many :images, as: :imageable, dependent: :destroy
+  has_many :journeys, dependent: :nullify
+  has_many :chapters, dependent: :nullify
 
   validates :name,
             presence: {

--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Milestone < ApplicationRecord
+  include ReviewSnapshot
+
+  belongs_to :journey
+
+  before_validation :assign_position, on: :create
+
+  validates :review_id,
+            uniqueness: {
+              scope: :journey_id,
+              message: I18n.t('messages.api.duplicate_milestone')
+            }
+  validates :position,
+            presence: true
+  validate :journey_must_be_unfinished, on: :create
+
+  private
+
+  def assign_position
+    return if journey.blank? || position.present?
+
+    self.position = (journey.milestones.maximum(:position) || 0) + 1
+  end
+
+  def journey_must_be_unfinished
+    return if journey.blank?
+    return unless journey.finished?
+
+    errors.add(:base, I18n.t('messages.api.journey_already_finished'))
+  end
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -11,6 +11,8 @@ class Review < ApplicationRecord
   has_many :comments, as: :commentable
   has_many :votes, as: :votable, dependent: :destroy
   has_many :voters, through: :votes, source: :voter, source_type: User.name
+  has_many :milestones, dependent: :nullify
+  has_many :journey_checkins, dependent: :nullify
 
   before_validation :remove_carriage_return
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ApplicationRecord
            dependent: :destroy,
            inverse_of: :invitee
   has_many :votes, as: :voter, dependent: :destroy
+  has_many :journeys, dependent: :destroy
+  has_many :chapters, dependent: :destroy
   has_many :owned_images, class_name: 'Image', dependent: :destroy
   has_many :images, as: :imageable, dependent: :destroy
   has_one :push_notification, dependent: :destroy

--- a/app/views/chapters/index.jbuilder
+++ b/app/views/chapters/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @chapters, partial: 'partials/chapter', as: :chapter

--- a/app/views/chapters/show.jbuilder
+++ b/app/views/chapters/show.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/chapter', chapter: @chapter

--- a/app/views/guest/chapters/index.jbuilder
+++ b/app/views/guest/chapters/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @chapters, partial: 'partials/guest/chapter', as: :chapter

--- a/app/views/guest/chapters/show.jbuilder
+++ b/app/views/guest/chapters/show.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/guest/chapter', chapter: @chapter

--- a/app/views/guest/users/chapters/index.jbuilder
+++ b/app/views/guest/users/chapters/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @chapters, partial: 'partials/guest/chapter', as: :chapter

--- a/app/views/maps/chapters/create.jbuilder
+++ b/app/views/maps/chapters/create.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/chapter', chapter: @chapter

--- a/app/views/maps/journeys/create.jbuilder
+++ b/app/views/maps/journeys/create.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/journey', journey: @journey

--- a/app/views/me/chapters/index.jbuilder
+++ b/app/views/me/chapters/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @chapters, partial: 'partials/chapter', as: :chapter

--- a/app/views/me/chapters/show.jbuilder
+++ b/app/views/me/chapters/show.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/chapter', chapter: @chapter

--- a/app/views/me/chapters/update.jbuilder
+++ b/app/views/me/chapters/update.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/chapter', chapter: @chapter

--- a/app/views/me/journeys/checkins/create.jbuilder
+++ b/app/views/me/journeys/checkins/create.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/journey_checkin', journey_checkin: @checkin

--- a/app/views/me/journeys/finish.jbuilder
+++ b/app/views/me/journeys/finish.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/journey', journey: @journey

--- a/app/views/me/journeys/index.jbuilder
+++ b/app/views/me/journeys/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @journeys, partial: 'partials/journey_summary', as: :journey

--- a/app/views/me/journeys/milestones/create.jbuilder
+++ b/app/views/me/journeys/milestones/create.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/milestone', milestone: @milestone

--- a/app/views/me/journeys/show.jbuilder
+++ b/app/views/me/journeys/show.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/journey', journey: @journey

--- a/app/views/me/journeys/start.jbuilder
+++ b/app/views/me/journeys/start.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/journey', journey: @journey

--- a/app/views/partials/_chapter.jbuilder
+++ b/app/views/partials/_chapter.jbuilder
@@ -1,0 +1,24 @@
+json.id chapter.id
+json.map_id chapter.map_id
+json.journey_id chapter.journey_id
+json.title chapter.title
+json.status chapter.status
+json.content chapter.content
+json.author do
+  json.id chapter.user.id
+  json.name chapter.user.name
+  json.image chapter.user.image_variants
+  json.image_url chapter.user.image_url
+end
+if chapter.map.present?
+  json.map do
+    json.id chapter.map_id
+    json.name chapter.map.name
+    json.private chapter.map.private
+  end
+else
+  json.map nil
+end
+json.editable current_user.author?(chapter)
+json.created_at chapter.created_at
+json.updated_at chapter.updated_at

--- a/app/views/partials/_journey.jbuilder
+++ b/app/views/partials/_journey.jbuilder
@@ -1,0 +1,19 @@
+json.id journey.id
+json.map_id journey.map_id
+json.started_at journey.started_at
+json.finished_at journey.finished_at
+json.milestones journey.milestones, partial: 'partials/milestone', as: :milestone
+json.checkins journey.checkins, partial: 'partials/journey_checkin', as: :journey_checkin
+json.encoded_path journey.encoded_path
+json.chapter_id journey.chapter&.id
+if journey.map.present?
+  json.map do
+    json.id journey.map_id
+    json.name journey.map.name
+    json.private journey.map.private
+  end
+else
+  json.map nil
+end
+json.created_at journey.created_at
+json.updated_at journey.updated_at

--- a/app/views/partials/_journey_checkin.jbuilder
+++ b/app/views/partials/_journey_checkin.jbuilder
@@ -1,0 +1,8 @@
+json.id journey_checkin.id
+json.review_id journey_checkin.review_id
+json.spot do
+  json.name journey_checkin.name
+  json.latitude journey_checkin.lat
+  json.longitude journey_checkin.lng
+end
+json.checked_in_at journey_checkin.created_at

--- a/app/views/partials/_journey_summary.jbuilder
+++ b/app/views/partials/_journey_summary.jbuilder
@@ -1,0 +1,18 @@
+json.id journey.id
+json.map_id journey.map_id
+json.started_at journey.started_at
+json.finished_at journey.finished_at
+json.milestones_count journey.milestones.length
+json.checkins_count journey.checkins.length
+json.chapter_id journey.chapter&.id
+if journey.map.present?
+  json.map do
+    json.id journey.map_id
+    json.name journey.map.name
+    json.private journey.map.private
+  end
+else
+  json.map nil
+end
+json.created_at journey.created_at
+json.updated_at journey.updated_at

--- a/app/views/partials/_milestone.jbuilder
+++ b/app/views/partials/_milestone.jbuilder
@@ -1,0 +1,5 @@
+json.id milestone.id
+json.review_id milestone.review_id
+json.name milestone.name
+json.latitude milestone.lat
+json.longitude milestone.lng

--- a/app/views/partials/guest/_chapter.jbuilder
+++ b/app/views/partials/guest/_chapter.jbuilder
@@ -1,0 +1,19 @@
+json.id chapter.id
+json.map_id chapter.map_id
+json.journey_id chapter.journey_id
+json.title chapter.title
+json.status chapter.status
+json.content chapter.content
+json.author do
+  json.id chapter.user.id
+  json.name chapter.user.name
+  json.image chapter.user.image_variants
+  json.image_url chapter.user.image_url
+end
+json.map do
+  json.id chapter.map_id
+  json.name chapter.map.name
+  json.private chapter.map.private
+end
+json.created_at chapter.created_at
+json.updated_at chapter.updated_at

--- a/app/views/users/chapters/index.jbuilder
+++ b/app/views/users/chapters/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @chapters, partial: 'partials/chapter', as: :chapter

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,3 +62,20 @@ en:
 
       registration_token_is_required: Registration token is required.
       registration_token_is_duplicated: Registration token is duplicated.
+
+      duplicate_unfinished_journey: An unfinished journey already exists on this map.
+      journey_already_started: The journey has already started.
+      journey_not_started: The journey has not started yet.
+      journey_already_finished: The journey has already finished.
+      journey_not_in_progress: The journey is not in progress.
+      journey_encoded_path_exceed: The journey path is too large.
+      duplicate_milestone: The pin is already added as a milestone.
+      duplicate_checkin: The journey has already checked in at this pin.
+      review_not_on_journey_map: The pin does not belong to the map of the journey.
+
+      chapter_title_required: Chapter title is required.
+      chapter_title_exceed: "Chapter title is too long. (Max: 100)"
+      chapter_content_invalid: Chapter content is not a valid document.
+      chapter_content_exceed: Chapter content is too large.
+      chapter_journey_mismatch: The journey does not belong to the author or the map of the chapter.
+      duplicate_chapter_for_journey: A chapter has already been created for this journey.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,3 +31,20 @@ ja:
 
       registration_token_is_required: 登録トークンを入力してください。
       registration_token_is_duplicated: 既に登録されているトークンです。
+
+      duplicate_unfinished_journey: このマップには未完了の旅が既にあります。
+      journey_already_started: この旅は既に開始されています。
+      journey_not_started: この旅はまだ開始されていません。
+      journey_already_finished: この旅は既に終了しています。
+      journey_not_in_progress: 進行中の旅ではありません。
+      journey_encoded_path_exceed: 旅の経路データが大きすぎます。
+      duplicate_milestone: このピンは既にマイルストーンに追加されています。
+      duplicate_checkin: このピンには既にチェックイン済みです。
+      review_not_on_journey_map: このピンは旅のマップに属していません。
+
+      chapter_title_required: チャプターのタイトルを入力してください。
+      chapter_title_exceed: "チャプターのタイトルが長すぎます。(最大: 100 文字)"
+      chapter_content_invalid: チャプターの本文の形式が正しくありません。
+      chapter_content_exceed: チャプターの本文が大きすぎます。
+      chapter_journey_mismatch: 指定された旅はチャプターの著者またはマップに属していません。
+      duplicate_chapter_for_journey: この旅のチャプターは既に作成されています。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       resources :maps, only: [:index]
       resources :reviews, only: [:index]
       resources :bookmarks, only: [:index]
+      resources :chapters, only: [:index]
       resource :push_notification, only: [:update]
     end
   end
@@ -14,6 +15,8 @@ Rails.application.routes.draw do
       resources :coauthors, only: %i[index destroy]
       resource :bookmark, only: %i[create destroy]
       resources :coauthorship_invitations, only: [:create]
+      resources :journeys, only: [:create]
+      resources :chapters, only: [:create]
     end
   end
   resources :coauthorship_invitations, only: [:index] do
@@ -34,6 +37,20 @@ Rails.application.routes.draw do
       end
     end
   end
+  namespace :me do
+    resources :journeys, only: %i[index show destroy] do
+      member do
+        post :start
+        post :finish
+      end
+      scope module: :journeys do
+        resources :milestones, only: %i[create destroy]
+        resources :checkins, only: %i[create destroy]
+      end
+    end
+    resources :chapters, only: %i[index show update destroy]
+  end
+  resources :chapters, only: %i[index show]
   resources :inappropriate_contents, only: [:create]
   resources :notifications, only: %i[index update]
   resources :images, only: [:create]
@@ -51,11 +68,13 @@ Rails.application.routes.draw do
       end
     end
     resources :reviews, only: %i[index show]
+    resources :chapters, only: %i[index show]
     resources :users, only: %i[show] do
       scope module: :users do
         resources :maps, only: [:index]
         resources :reviews, only: [:index]
         resources :bookmarks, only: [:index]
+        resources :chapters, only: [:index]
       end
     end
   end

--- a/db/migrate/20260713043035_create_journeys.rb
+++ b/db/migrate/20260713043035_create_journeys.rb
@@ -1,0 +1,15 @@
+class CreateJourneys < ActiveRecord::Migration[7.2]
+  def change
+    create_table :journeys do |t|
+      t.references :user, null: false, index: false, foreign_key: true
+      t.references :map, foreign_key: true
+      t.datetime :started_at
+      t.datetime :finished_at
+      t.text :encoded_path, size: :medium
+
+      t.timestamps
+
+      t.index %i[user_id map_id finished_at]
+    end
+  end
+end

--- a/db/migrate/20260713043046_create_milestones.rb
+++ b/db/migrate/20260713043046_create_milestones.rb
@@ -1,0 +1,17 @@
+class CreateMilestones < ActiveRecord::Migration[7.2]
+  def change
+    create_table :milestones do |t|
+      t.references :journey, null: false, index: false, foreign_key: true
+      t.references :review, foreign_key: true
+      t.integer :position, null: false
+      t.string :name, null: false
+      t.decimal :latitude, precision: 16, scale: 6, null: false
+      t.decimal :longitude, precision: 16, scale: 6, null: false
+
+      t.timestamps
+
+      t.index %i[journey_id review_id], unique: true
+      t.index %i[journey_id position]
+    end
+  end
+end

--- a/db/migrate/20260713043047_create_journey_checkins.rb
+++ b/db/migrate/20260713043047_create_journey_checkins.rb
@@ -1,0 +1,15 @@
+class CreateJourneyCheckins < ActiveRecord::Migration[7.2]
+  def change
+    create_table :journey_checkins do |t|
+      t.references :journey, null: false, index: false, foreign_key: true
+      t.references :review, foreign_key: true
+      t.string :name, null: false
+      t.decimal :latitude, precision: 16, scale: 6, null: false
+      t.decimal :longitude, precision: 16, scale: 6, null: false
+
+      t.timestamps
+
+      t.index %i[journey_id review_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20260713043049_create_chapters.rb
+++ b/db/migrate/20260713043049_create_chapters.rb
@@ -1,0 +1,16 @@
+class CreateChapters < ActiveRecord::Migration[7.2]
+  def change
+    create_table :chapters do |t|
+      t.references :user, null: false, index: false, foreign_key: true
+      t.references :map, foreign_key: true
+      t.references :journey, index: { unique: true }, foreign_key: true
+      t.string :title, null: false
+      t.string :status, default: 'draft', null: false
+      t.json :content, null: false
+
+      t.timestamps
+
+      t.index %i[user_id status]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_23_010032) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_13_043049) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "map_id", null: false
     t.bigint "user_id", null: false
@@ -19,6 +19,20 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_23_010032) do
     t.index ["map_id", "user_id"], name: "index_bookmarks_on_map_id_and_user_id", unique: true
     t.index ["map_id"], name: "index_bookmarks_on_map_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "chapters", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "map_id"
+    t.bigint "journey_id"
+    t.string "title", null: false
+    t.string "status", default: "draft", null: false
+    t.json "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["journey_id"], name: "index_chapters_on_journey_id", unique: true
+    t.index ["map_id"], name: "index_chapters_on_map_id"
+    t.index ["user_id", "status"], name: "index_chapters_on_user_id_and_status"
   end
 
   create_table "coauthorship_invitations", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -88,6 +102,30 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_23_010032) do
     t.index ["user_id"], name: "index_inappropriate_contents_on_user_id"
   end
 
+  create_table "journey_checkins", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "journey_id", null: false
+    t.bigint "review_id"
+    t.string "name", null: false
+    t.decimal "latitude", precision: 16, scale: 6, null: false
+    t.decimal "longitude", precision: 16, scale: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["journey_id", "review_id"], name: "index_journey_checkins_on_journey_id_and_review_id", unique: true
+    t.index ["review_id"], name: "index_journey_checkins_on_review_id"
+  end
+
+  create_table "journeys", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "map_id"
+    t.datetime "started_at"
+    t.datetime "finished_at"
+    t.text "encoded_path", size: :medium
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["map_id"], name: "index_journeys_on_map_id"
+    t.index ["user_id", "map_id", "finished_at"], name: "index_journeys_on_user_id_and_map_id_and_finished_at"
+  end
+
   create_table "maps", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "name", null: false
@@ -102,6 +140,20 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_23_010032) do
     t.decimal "latitude", precision: 16, scale: 6, default: "0.0", null: false
     t.decimal "longitude", precision: 16, scale: 6, default: "0.0", null: false
     t.index ["user_id"], name: "index_maps_on_user_id"
+  end
+
+  create_table "milestones", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "journey_id", null: false
+    t.bigint "review_id"
+    t.integer "position", null: false
+    t.string "name", null: false
+    t.decimal "latitude", precision: 16, scale: 6, null: false
+    t.decimal "longitude", precision: 16, scale: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["journey_id", "position"], name: "index_milestones_on_journey_id_and_position"
+    t.index ["journey_id", "review_id"], name: "index_milestones_on_journey_id_and_review_id", unique: true
+    t.index ["review_id"], name: "index_milestones_on_review_id"
   end
 
   create_table "notifications", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -177,13 +229,22 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_23_010032) do
 
   add_foreign_key "bookmarks", "maps"
   add_foreign_key "bookmarks", "users"
+  add_foreign_key "chapters", "journeys"
+  add_foreign_key "chapters", "maps"
+  add_foreign_key "chapters", "users"
   add_foreign_key "coauthorship_invitations", "maps"
   add_foreign_key "coauthorship_invitations", "users", column: "invitee_id"
   add_foreign_key "coauthorship_invitations", "users", column: "inviter_id"
   add_foreign_key "coauthorships", "maps"
   add_foreign_key "coauthorships", "users"
   add_foreign_key "images", "users"
+  add_foreign_key "journey_checkins", "journeys"
+  add_foreign_key "journey_checkins", "reviews"
+  add_foreign_key "journeys", "maps"
+  add_foreign_key "journeys", "users"
   add_foreign_key "maps", "users"
+  add_foreign_key "milestones", "journeys"
+  add_foreign_key "milestones", "reviews"
   add_foreign_key "push_notifications", "users"
   add_foreign_key "reviews", "maps"
   add_foreign_key "reviews", "users"

--- a/test/controllers/chapters_controller_test.rb
+++ b/test/controllers/chapters_controller_test.rb
@@ -1,0 +1,101 @@
+require 'test_helper'
+
+class ChaptersControllerTest < ActionDispatch::IntegrationTest
+  test 'index should return published chapters on maps related to the user' do
+    stub_google_auth(users(:me)) do
+      get '/chapters',
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    ids = res.map { |chapter| chapter['id'] }
+
+    assert_includes ids, chapters(:my_published).id
+    assert_includes ids, chapters(:you_private_published_following).id
+    assert_not_includes ids, chapters(:you_published).id
+    assert_not_includes ids, chapters(:you_private_published_unfollowing).id
+    assert_not_includes ids, chapters(:my_draft).id
+    assert_not_includes ids, chapters(:you_draft).id
+  end
+
+  test 'index with next_timestamp should return only older chapters' do
+    stub_google_auth(users(:me)) do
+      get '/chapters',
+          params: { next_timestamp: '2026-06-08T00:00:00Z' },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal [chapters(:my_published).id], res.map { |chapter| chapter['id'] }
+  end
+
+  test 'show a published chapter of another user returns the content verbatim' do
+    stub_google_auth(users(:you)) do
+      get "/chapters/#{chapters(:my_published).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_not res['editable']
+    assert_equal chapters(:my_published).content['root'], res['content']['root']
+  end
+
+  test 'show a published chapter on a private map as a coauthor should be success' do
+    stub_google_auth(users(:me)) do
+      get "/chapters/#{chapters(:you_private_published_following).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal chapters(:you_private_published_following).id, res['id']
+    assert_not res['editable']
+  end
+
+  test 'show a published chapter on an unreferenceable private map should raise not found error' do
+    stub_google_auth(users(:me)) do
+      get "/chapters/#{chapters(:you_private_published_unfollowing).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'show a draft chapter of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      get "/chapters/#{chapters(:you_draft).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'show own draft chapter should be success' do
+    stub_google_auth(users(:me)) do
+      get "/chapters/#{chapters(:my_draft).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert res['editable']
+  end
+
+  test 'show a chapter without authentication should raise unauthorized error' do
+    get "/chapters/#{chapters(:my_published).id}"
+
+    assert_response :unauthorized
+  end
+end

--- a/test/controllers/guest/chapters_controller_test.rb
+++ b/test/controllers/guest/chapters_controller_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class Guest::ChaptersControllerTest < ActionDispatch::IntegrationTest
+  test 'index should return latest published chapters on public maps' do
+    get '/guest/chapters'
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    ids = res.map { |chapter| chapter['id'] }
+
+    assert_includes ids, chapters(:my_published).id
+    assert_includes ids, chapters(:you_published).id
+    assert_not_includes ids, chapters(:you_private_published_following).id
+    assert_not_includes ids, chapters(:my_draft).id
+  end
+
+  test 'show a published chapter returns the content verbatim' do
+    get "/guest/chapters/#{chapters(:my_published).id}"
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal chapters(:my_published).id, res['id']
+    assert_not res.key?('editable')
+    assert_equal chapters(:my_published).content['root'], res['content']['root']
+  end
+
+  test 'show a draft chapter should raise not found error' do
+    get "/guest/chapters/#{chapters(:my_draft).id}"
+
+    assert_response :not_found
+  end
+
+  test 'show a published chapter on a private map should raise not found error' do
+    get "/guest/chapters/#{chapters(:you_private_published_unfollowing).id}"
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/guest/users/chapters_controller_test.rb
+++ b/test/controllers/guest/users/chapters_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Guest::Users::ChaptersControllerTest < ActionDispatch::IntegrationTest
+  test 'index should return only published chapters' do
+    get "/guest/users/#{users(:me).id}/chapters"
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal [chapters(:my_published).id], res.map { |chapter| chapter['id'] }
+  end
+
+  test 'index should exclude published chapters on private maps' do
+    get "/guest/users/#{users(:you).id}/chapters"
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    ids = res.map { |chapter| chapter['id'] }
+
+    assert_includes ids, chapters(:you_published).id
+    assert_not_includes ids, chapters(:you_private_published_following).id
+    assert_not_includes ids, chapters(:you_private_published_unfollowing).id
+  end
+end

--- a/test/controllers/maps/chapters_controller_test.rb
+++ b/test/controllers/maps/chapters_controller_test.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+
+class Maps::ChaptersControllerTest < ActionDispatch::IntegrationTest
+  LEXICAL_DOCUMENT = {
+    root: {
+      type: 'root',
+      version: 1,
+      children: []
+    }
+  }.freeze
+
+  test 'create a chapter recording a journey should be success' do
+    assert_difference 'Chapter.count', 1 do
+      stub_google_auth(users(:me)) do
+        post "/maps/#{maps(:private).id}/chapters",
+             params: {
+               journey_id: journeys(:my_in_progress).id,
+               title: 'A walk',
+               content: LEXICAL_DOCUMENT
+             },
+             headers: { 'Authorization': 'Bearer dummytoken' },
+             as: :json
+      end
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal journeys(:my_in_progress).id, res['journey_id']
+    assert_equal 'draft', res['status']
+    assert res['editable']
+  end
+
+  test 'create a chapter without a journey should be success' do
+    assert_difference 'Chapter.count', 1 do
+      stub_google_auth(users(:you)) do
+        post "/maps/#{maps(:public_one).id}/chapters",
+             params: { title: 'A walk', content: LEXICAL_DOCUMENT },
+             headers: { 'Authorization': 'Bearer dummytoken' },
+             as: :json
+      end
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_nil res['journey_id']
+  end
+
+  test 'create a chapter with a journey of another user should raise not found error' do
+    stub_google_auth(users(:you)) do
+      post "/maps/#{maps(:public_one).id}/chapters",
+           params: {
+             journey_id: journeys(:my_finished).id,
+             title: 'A walk',
+             content: LEXICAL_DOCUMENT
+           },
+           headers: { 'Authorization': 'Bearer dummytoken' },
+           as: :json
+    end
+
+    assert_response :not_found
+  end
+
+  test 'create a chapter with a journey on another map should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      post "/maps/#{maps(:public_one).id}/chapters",
+           params: {
+             journey_id: journeys(:my_in_progress).id,
+             title: 'A walk',
+             content: LEXICAL_DOCUMENT
+           },
+           headers: { 'Authorization': 'Bearer dummytoken' },
+           as: :json
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'create a chapter on an unreferenceable private map should raise not found error' do
+    stub_google_auth(users(:me)) do
+      post "/maps/#{maps(:private_unfollowing).id}/chapters",
+           params: { title: 'A walk', content: LEXICAL_DOCUMENT },
+           headers: { 'Authorization': 'Bearer dummytoken' },
+           as: :json
+    end
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/maps/journeys_controller_test.rb
+++ b/test/controllers/maps/journeys_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class Maps::JourneysControllerTest < ActionDispatch::IntegrationTest
+  test 'create a journey on a referenceable map should be success' do
+    assert_difference 'Journey.count', 1 do
+      stub_google_auth(users(:you)) do
+        post "/maps/#{maps(:public_two).id}/journeys",
+             headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal maps(:public_two).id, res['map_id']
+    assert_nil res['started_at']
+    assert_empty res['milestones']
+    assert_empty res['checkins']
+    assert_nil res['encoded_path']
+  end
+
+  test 'create a journey on an unreferenceable private map should raise not found error' do
+    stub_google_auth(users(:me)) do
+      post "/maps/#{maps(:private_unfollowing).id}/journeys",
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'create a second unfinished journey on the same map should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      post "/maps/#{maps(:public_one).id}/journeys",
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'create a journey without authentication should raise unauthorized error' do
+    post "/maps/#{maps(:public_one).id}/journeys"
+
+    assert_response :unauthorized
+  end
+end

--- a/test/controllers/me/chapters_controller_test.rb
+++ b/test/controllers/me/chapters_controller_test.rb
@@ -1,0 +1,138 @@
+require 'test_helper'
+
+class Me::ChaptersControllerTest < ActionDispatch::IntegrationTest
+  test 'index should return own chapters in both statuses' do
+    stub_google_auth(users(:me)) do
+      get '/me/chapters',
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal [chapters(:my_draft).id, chapters(:my_published).id].sort,
+                 res.map { |chapter| chapter['id'] }.sort
+  end
+
+  test 'show own draft chapter should be success' do
+    stub_google_auth(users(:me)) do
+      get "/me/chapters/#{chapters(:my_draft).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal chapters(:my_draft).id, res['id']
+    assert res['editable']
+  end
+
+  test 'show a chapter of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      get "/me/chapters/#{chapters(:you_published).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'update title and content should be success' do
+    stub_google_auth(users(:me)) do
+      put "/me/chapters/#{chapters(:my_draft).id}",
+          params: {
+            title: 'Renamed chapter',
+            content: { root: { type: 'root', version: 1, children: [] } }
+          },
+          headers: { 'Authorization': 'Bearer dummytoken' },
+          as: :json
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal 'Renamed chapter', res['title']
+    assert_empty res['content']['root']['children']
+  end
+
+  test 'publish a draft chapter should be success' do
+    stub_google_auth(users(:me)) do
+      put "/me/chapters/#{chapters(:my_draft).id}",
+          params: { status: 'published' },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal 'published', res['status']
+  end
+
+  test 'revert a published chapter to draft should be success' do
+    stub_google_auth(users(:me)) do
+      put "/me/chapters/#{chapters(:my_published).id}",
+          params: { status: 'draft' },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal 'draft', res['status']
+  end
+
+  test 'update with an unknown status should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      put "/me/chapters/#{chapters(:my_draft).id}",
+          params: { status: 'archived' },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'update with an invalid content should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      put "/me/chapters/#{chapters(:my_draft).id}",
+          params: { content: { foo: 'bar' } },
+          headers: { 'Authorization': 'Bearer dummytoken' },
+          as: :json
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'update a chapter of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      put "/me/chapters/#{chapters(:you_draft).id}",
+          params: { title: 'Hijacked' },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'destroy own chapter should be success' do
+    assert_difference 'Chapter.count', -1 do
+      stub_google_auth(users(:me)) do
+        delete "/me/chapters/#{chapters(:my_draft).id}",
+               headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+  end
+
+  test 'destroy a chapter of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      delete "/me/chapters/#{chapters(:you_draft).id}",
+             headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/me/journeys/checkins_controller_test.rb
+++ b/test/controllers/me/journeys/checkins_controller_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class Me::Journeys::CheckinsControllerTest < ActionDispatch::IntegrationTest
+  test 'check in on an in-progress journey should be success' do
+    assert_difference 'JourneyCheckin.count', 1 do
+      stub_google_auth(users(:me)) do
+        post "/me/journeys/#{journeys(:my_in_progress).id}/checkins",
+             params: { review_id: reviews(:private_you).id },
+             headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal reviews(:private_you).id, res['review_id']
+    assert_equal reviews(:private_you).name, res['spot']['name']
+    assert_predicate res['checked_in_at'], :present?
+  end
+
+  test 'check in on an unstarted journey should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_unstarted).id}/checkins",
+           params: { review_id: reviews(:public_one).id },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'check in at the same pin twice should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_in_progress).id}/checkins",
+           params: { review_id: reviews(:private).id },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'check in on a journey of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:you_in_progress).id}/checkins",
+           params: { review_id: reviews(:public_unfollowing).id },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'remove a checkin from an unfinished journey should be success' do
+    assert_difference 'JourneyCheckin.count', -1 do
+      stub_google_auth(users(:me)) do
+        delete "/me/journeys/#{journeys(:my_in_progress).id}/checkins/#{journey_checkins(:my_in_progress_private).id}",
+               headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+  end
+end

--- a/test/controllers/me/journeys/milestones_controller_test.rb
+++ b/test/controllers/me/journeys/milestones_controller_test.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+
+class Me::Journeys::MilestonesControllerTest < ActionDispatch::IntegrationTest
+  test 'add a milestone to an unstarted journey should be success' do
+    assert_difference 'Milestone.count', 1 do
+      stub_google_auth(users(:me)) do
+        post "/me/journeys/#{journeys(:my_unstarted).id}/milestones",
+             params: { review_id: reviews(:public_one).id },
+             headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal reviews(:public_one).id, res['review_id']
+    assert_equal reviews(:public_one).name, res['name']
+  end
+
+  test 'add a milestone to an in-progress journey should be success' do
+    assert_difference 'Milestone.count', 1 do
+      stub_google_auth(users(:me)) do
+        post "/me/journeys/#{journeys(:my_in_progress).id}/milestones",
+             params: { review_id: reviews(:private_you).id },
+             headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+  end
+
+  test 'add the same review twice should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_in_progress).id}/milestones",
+           params: { review_id: reviews(:private).id },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'add a review on another map should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_unstarted).id}/milestones",
+           params: { review_id: reviews(:private).id },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'add a milestone to a finished journey should raise not found error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_finished).id}/milestones",
+           params: { review_id: reviews(:public_two).id },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'add a milestone to a journey of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:you_in_progress).id}/milestones",
+           params: { review_id: reviews(:public_unfollowing).id },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'remove a milestone from an unfinished journey should be success' do
+    assert_difference 'Milestone.count', -1 do
+      stub_google_auth(users(:me)) do
+        delete "/me/journeys/#{journeys(:my_in_progress).id}/milestones/#{milestones(:my_in_progress_first).id}",
+               headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+  end
+
+  test 'remove a milestone from a finished journey should raise not found error' do
+    stub_google_auth(users(:me)) do
+      delete "/me/journeys/#{journeys(:my_finished).id}/milestones/#{milestones(:my_finished_first).id}",
+             headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/me/journeys_controller_test.rb
+++ b/test/controllers/me/journeys_controller_test.rb
@@ -1,0 +1,138 @@
+require 'test_helper'
+
+class Me::JourneysControllerTest < ActionDispatch::IntegrationTest
+  test 'index should return all own journeys with counts' do
+    stub_google_auth(users(:me)) do
+      get '/me/journeys',
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal 3, res.length
+
+    in_progress = res.find { |journey| journey['id'] == journeys(:my_in_progress).id }
+
+    assert_equal 1, in_progress['milestones_count']
+    assert_equal 1, in_progress['checkins_count']
+    assert_equal maps(:private).name, in_progress['map']['name']
+  end
+
+  test 'show own journey should return milestones, checkins and encoded path' do
+    stub_google_auth(users(:me)) do
+      get "/me/journeys/#{journeys(:my_in_progress).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal journeys(:my_in_progress).id, res['id']
+    assert_equal [reviews(:private).id], res['milestones'].map { |milestone| milestone['review_id'] }
+    assert_equal [reviews(:private).id], res['checkins'].map { |checkin| checkin['review_id'] }
+    assert_equal journeys(:my_in_progress).encoded_path, res['encoded_path']
+    assert_equal maps(:private).name, res['map']['name']
+  end
+
+  test 'show journey of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      get "/me/journeys/#{journeys(:you_in_progress).id}",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'start an unstarted journey should be success' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_unstarted).id}/start",
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_predicate res['started_at'], :present?
+    assert_nil res['finished_at']
+  end
+
+  test 'start a started journey should raise conflict error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_in_progress).id}/start",
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :conflict
+  end
+
+  test 'start a finished journey should raise not found error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_finished).id}/start",
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'finish a started journey should be success' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_in_progress).id}/finish",
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_predicate res['finished_at'], :present?
+  end
+
+  test 'finish a started journey with an encoded path should store it' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_in_progress).id}/finish",
+           params: { encoded_path: 'a~l~Fjk~uOwHJy@P' },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_predicate res['finished_at'], :present?
+    assert_equal 'a~l~Fjk~uOwHJy@P', res['encoded_path']
+  end
+
+  test 'finish an unstarted journey should raise conflict error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_unstarted).id}/finish",
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :conflict
+  end
+
+  test 'destroy own journey should destroy its milestones' do
+    assert_difference ['Journey.count', 'Milestone.count'], -1 do
+      stub_google_auth(users(:me)) do
+        delete "/me/journeys/#{journeys(:my_finished).id}",
+               headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    assert_nil chapters(:my_draft).reload.journey_id
+  end
+
+  test 'destroy journey of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      delete "/me/journeys/#{journeys(:you_in_progress).id}",
+             headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/users/chapters_controller_test.rb
+++ b/test/controllers/users/chapters_controller_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class Users::ChaptersControllerTest < ActionDispatch::IntegrationTest
+  test 'index of another user returns published chapters on referenceable maps only' do
+    stub_google_auth(users(:me)) do
+      get "/users/#{users(:you).id}/chapters",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    ids = res.map { |chapter| chapter['id'] }
+
+    assert_includes ids, chapters(:you_published).id
+    assert_includes ids, chapters(:you_private_published_following).id
+    assert_not_includes ids, chapters(:you_private_published_unfollowing).id
+    assert_not_includes ids, chapters(:you_draft).id
+  end
+
+  test 'index with own uid should return only published chapters' do
+    stub_google_auth(users(:me)) do
+      get "/users/#{users(:me).uid}/chapters",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal [chapters(:my_published).id], res.map { |chapter| chapter['id'] }
+  end
+end

--- a/test/fixtures/chapters.yml
+++ b/test/fixtures/chapters.yml
@@ -1,0 +1,94 @@
+my_draft:
+  user: me
+  map: public_one
+  journey: my_finished
+  title: My draft chapter
+  status: draft
+  content:
+    root:
+      type: root
+      version: 1
+      children:
+        - type: journey
+          version: 1
+          journey_id: null
+          encoded_path: "_p~iF~ps|U_ulLnnqC"
+        - type: spot
+          version: 1
+          review_id: 1
+          name: This is a name
+          latitude: 35.681382
+          longitude: 139.766084
+
+my_published:
+  user: me
+  map: public_one
+  title: My published chapter
+  status: published
+  created_at: 2026-06-05 12:00:00
+  content:
+    root:
+      type: root
+      version: 1
+      children:
+        - type: journey
+          version: 1
+          journey_id: null
+          encoded_path: "_p~iF~ps|U_ulLnnqC"
+        - type: spot
+          version: 1
+          review_id: 1
+          name: This is a name
+          latitude: 35.681382
+          longitude: 139.766084
+
+you_draft:
+  user: you
+  map: public_unfollowing
+  title: Your draft chapter
+  status: draft
+  content:
+    root:
+      type: root
+      version: 1
+      children: []
+
+you_published:
+  user: you
+  map: public_unfollowing
+  title: Your published chapter
+  status: published
+  content:
+    root:
+      type: root
+      version: 1
+      children:
+        - type: spot
+          version: 1
+          review_id: 1
+          name: This is a name
+          latitude: 35.681382
+          longitude: 139.766084
+
+you_private_published_unfollowing:
+  user: you
+  map: private_unfollowing
+  title: Your private chapter that me cannot reference
+  status: published
+  content:
+    root:
+      type: root
+      version: 1
+      children: []
+
+you_private_published_following:
+  user: you
+  map: private_following
+  title: Your private chapter that me coauthors
+  status: published
+  created_at: 2026-06-10 12:00:00
+  content:
+    root:
+      type: root
+      version: 1
+      children: []

--- a/test/fixtures/journey_checkins.yml
+++ b/test/fixtures/journey_checkins.yml
@@ -1,0 +1,13 @@
+my_in_progress_private:
+  journey: my_in_progress
+  review: private
+  name: This is a name
+  latitude: 35.681382
+  longitude: 139.766084
+
+my_finished_public_one:
+  journey: my_finished
+  review: public_one
+  name: This is a name
+  latitude: 35.681382
+  longitude: 139.766084

--- a/test/fixtures/journeys.yml
+++ b/test/fixtures/journeys.yml
@@ -1,0 +1,26 @@
+my_unstarted:
+  user: me
+  map: public_one
+
+my_in_progress:
+  user: me
+  map: private
+  started_at: 2026-07-01 10:00:00
+  encoded_path: "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+
+my_finished:
+  user: me
+  map: public_one
+  started_at: 2026-06-01 10:00:00
+  finished_at: 2026-06-01 12:00:00
+
+you_finished:
+  user: you
+  map: public_one
+  started_at: 2026-06-02 10:00:00
+  finished_at: 2026-06-02 12:00:00
+
+you_in_progress:
+  user: you
+  map: public_unfollowing
+  started_at: 2026-07-01 10:00:00

--- a/test/fixtures/milestones.yml
+++ b/test/fixtures/milestones.yml
@@ -1,0 +1,15 @@
+my_in_progress_first:
+  journey: my_in_progress
+  review: private
+  position: 1
+  name: This is a name
+  latitude: 35.681382
+  longitude: 139.766084
+
+my_finished_first:
+  journey: my_finished
+  review: public_one
+  position: 1
+  name: This is a name
+  latitude: 35.681382
+  longitude: 139.766084

--- a/test/models/chapter_test.rb
+++ b/test/models/chapter_test.rb
@@ -1,0 +1,113 @@
+require 'test_helper'
+
+class ChapterTest < ActiveSupport::TestCase
+  LEXICAL_DOCUMENT = {
+    'root' => {
+      'type' => 'root',
+      'version' => 1,
+      'children' => []
+    }
+  }.freeze
+
+  test 'valid chapter without a journey' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT
+    )
+
+    assert chapter.valid?
+  end
+
+  test 'content must be a lexical document' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: { 'foo' => 'bar' }
+    )
+
+    assert_not chapter.valid?
+  end
+
+  test 'journey of another user cannot be recorded' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_one),
+      journey: journeys(:my_finished),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT
+    )
+
+    assert_not chapter.valid?
+  end
+
+  test 'journey on another map cannot be recorded' do
+    chapter = Chapter.new(
+      user: users(:me),
+      map: maps(:public_one),
+      journey: journeys(:my_in_progress),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT
+    )
+
+    assert_not chapter.valid?
+  end
+
+  test 'journey cannot be recorded in two chapters' do
+    chapter = Chapter.new(
+      user: users(:me),
+      map: maps(:public_one),
+      journey: chapters(:my_draft).journey,
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT
+    )
+
+    assert_not chapter.valid?
+  end
+
+  test 'destroying the map keeps the chapter without a map' do
+    chapter = chapters(:my_draft)
+
+    chapter.map.destroy!
+
+    assert_nil chapter.reload.map_id
+  end
+
+  test 'readable_by includes published chapters on referenceable maps' do
+    readable = Chapter.readable_by(users(:me))
+
+    assert_includes readable, chapters(:my_published)
+    assert_includes readable, chapters(:you_published)
+    assert_includes readable, chapters(:you_private_published_following)
+  end
+
+  test 'readable_by excludes published chapters on unreferenceable private maps' do
+    readable = Chapter.readable_by(users(:me))
+
+    assert_not_includes readable, chapters(:you_private_published_unfollowing)
+  end
+
+  test 'readable_by includes own drafts' do
+    readable = Chapter.readable_by(users(:me))
+
+    assert_includes readable, chapters(:my_draft)
+  end
+
+  test 'readable_by excludes drafts of other users' do
+    readable = Chapter.readable_by(users(:me))
+
+    assert_not_includes readable, chapters(:you_draft)
+  end
+
+  test 'public_open includes only published chapters on public maps' do
+    public_chapters = Chapter.public_open
+
+    assert_includes public_chapters, chapters(:my_published)
+    assert_includes public_chapters, chapters(:you_published)
+    assert_not_includes public_chapters, chapters(:you_private_published_following)
+    assert_not_includes public_chapters, chapters(:my_draft)
+  end
+
+end

--- a/test/models/journey_checkin_test.rb
+++ b/test/models/journey_checkin_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class JourneyCheckinTest < ActiveSupport::TestCase
+  test 'checkin on an in-progress journey is created' do
+    checkin = journeys(:my_in_progress).checkins.create!(review: reviews(:private_you))
+
+    assert_predicate checkin, :persisted?
+  end
+
+  test 'checkin on an unstarted journey is invalid' do
+    checkin = journeys(:my_unstarted).checkins.build(review: reviews(:public_one))
+
+    assert_not checkin.valid?
+  end
+
+  test 'checkin on a finished journey is invalid' do
+    checkin = journeys(:my_finished).checkins.build(review: reviews(:public_two))
+
+    assert_not checkin.valid?
+  end
+
+  test 'same review cannot be checked in twice on a journey' do
+    checkin = journeys(:my_in_progress).checkins.build(review: reviews(:private))
+
+    assert_not checkin.valid?
+  end
+
+  test 'review on another map cannot be checked in' do
+    checkin = journeys(:my_in_progress).checkins.build(review: reviews(:public_one))
+
+    assert_not checkin.valid?
+  end
+end

--- a/test/models/journey_test.rb
+++ b/test/models/journey_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class JourneyTest < ActiveSupport::TestCase
+  test 'valid journey on a referenceable map' do
+    journey = Journey.new(user: users(:you), map: maps(:public_two))
+
+    assert journey.valid?
+  end
+
+  test 'second unfinished journey on the same map is invalid' do
+    journey = Journey.new(user: users(:me), map: maps(:public_one))
+
+    assert_not journey.valid?
+  end
+
+  test 'new journey is allowed on a map with only finished journeys' do
+    journeys(:my_unstarted).destroy!
+
+    journey = Journey.new(user: users(:me), map: maps(:public_one))
+
+    assert journey.valid?
+  end
+
+  test 'start! stamps started_at' do
+    journey = journeys(:my_unstarted)
+
+    journey.start!
+
+    assert_predicate journey, :in_progress?
+  end
+
+  test 'start! on a started journey raises a conflict' do
+    assert_raises Exceptions::Conflict do
+      journeys(:my_in_progress).start!
+    end
+  end
+
+  test 'finish! stamps finished_at' do
+    journey = journeys(:my_in_progress)
+
+    journey.finish!
+
+    assert_predicate journey, :finished?
+  end
+
+  test 'finish! stores the encoded path submitted with it' do
+    journey = journeys(:my_in_progress)
+
+    journey.finish!(encoded_path: 'a~l~Fjk~uOwHJy@P')
+
+    assert_predicate journey, :finished?
+    assert_equal 'a~l~Fjk~uOwHJy@P', journey.encoded_path
+  end
+
+  test 'finish! on an unstarted journey raises a conflict' do
+    assert_raises Exceptions::Conflict do
+      journeys(:my_unstarted).finish!
+    end
+  end
+
+  test 'destroying the map keeps the journey without a map' do
+    journey = journeys(:my_in_progress)
+
+    journey.map.destroy!
+
+    assert_nil journey.reload.map_id
+  end
+
+  test 'destroying a journey nullifies the chapter reference' do
+    chapter = chapters(:my_draft)
+
+    chapter.journey.destroy!
+
+    assert_nil chapter.reload.journey_id
+  end
+end

--- a/test/models/milestone_test.rb
+++ b/test/models/milestone_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class MilestoneTest < ActiveSupport::TestCase
+  test 'creation snapshots the review name and coordinates' do
+    review = reviews(:public_one)
+    milestone = journeys(:my_unstarted).milestones.create!(review: review)
+
+    assert_equal review.name, milestone.name
+    assert_equal review.latitude, milestone.latitude
+    assert_equal review.longitude, milestone.longitude
+  end
+
+  test 'position is assigned in addition order' do
+    journey = journeys(:my_in_progress)
+    milestone = journey.milestones.create!(review: reviews(:private_you))
+
+    assert_equal 2, milestone.position
+  end
+
+  test 'same review cannot be added twice to a journey' do
+    milestone = journeys(:my_in_progress).milestones.build(review: reviews(:private))
+
+    assert_not milestone.valid?
+  end
+
+  test 'review on another map cannot be added' do
+    milestone = journeys(:my_unstarted).milestones.build(review: reviews(:private))
+
+    assert_not milestone.valid?
+  end
+
+  test 'milestone cannot be added to a finished journey' do
+    milestone = journeys(:my_finished).milestones.build(review: reviews(:public_two))
+
+    assert_not milestone.valid?
+  end
+
+  test 'destroying the review keeps the milestone with its snapshot' do
+    milestone = milestones(:my_in_progress_first)
+
+    milestone.review.destroy!
+
+    assert_nil milestone.reload.review_id
+    assert_equal 'This is a name', milestone.name
+  end
+end


### PR DESCRIPTION
# Summary

Adds the Rails resources backing the Milestones / Journeys / Chapters experience built frontend-first in [qoodish-web#1075](https://github.com/yusuke-suzuki/qoodish-web/pull/1075). A journey records one walk on a map (its milestones, check-ins, and trail); a chapter is the Lexical document written up from a journey. The JSON responses follow the contract that PR settled on, so the frontend can move from its localStorage placeholder to the API without reshaping data.

# Motivation

The journey and chapter data in qoodish-web#1075 lives only in the browser's localStorage. It is lost across devices, cannot be shared, and cannot back the public chapter pages that PR plans. This change gives the data a server home and enforces the visibility and lifecycle rules the client cannot be trusted to hold.

# Changes

## Resources

- **Journey** — belongs to a user; created on a map but survives the map's deletion (`Map has_many :journeys, dependent: :nullify`), since a journey is the user's own activity record. Owns milestones, check-ins, and its recorded trail. The trail is stored as a Google encoded-polyline string (`encoded_path`): the client accumulates points during the walk and submits the whole encoded path when finishing (`POST /me/journeys/:id/finish`). Per-point timestamps are intentionally dropped — the journey's time window comes from `started_at`/`finished_at`, and check-ins carry their own times. At most one unfinished journey may exist per user per map. `start`/`finish` are server-stamped member actions; a finished journey is an immutable activity record.
- **Milestone** / **JourneyCheckin** — anchor to a `Review` and snapshot its name and coordinates at creation (shared `ReviewSnapshot` concern), so the record and any chapter generated from it stay renderable after the review changes or is deleted. The review reference is nullified on review deletion; the snapshot remains.
- **Chapter** — the user's writing; created on a map but likewise survives the map's deletion (`dependent: :nullify`). Stores its Lexical document as an opaque JSON column (validated only as a `root`-bearing object under a size limit). A `draft` is author-only; a `published` chapter is readable by anyone who can reference its map.

## Routing convention (`namespace :me`)

Resources whose scope is the authenticated user live under a `namespace :me` (mirroring `namespace :guest`), so the subject is explicit in the URI and the controllers are namespaced as `Me::*`. Reading a journey or chapter is `/me/...` rather than `/maps/:map_id/...`: both are user-owned resources that outlive their map, so the map does not belong in their identity. Map-scoped routes remain only for creation, where the map is a true input. This is the first API to adopt the convention; the existing root-level owner endpoints (`/reviews`, `/notifications`) are expected to migrate into `namespace :me` later.

## Endpoints

| Method | Path | Purpose |
| --- | --- | --- |
| GET | `/me/journeys` | Owner's journey log (summary rows) |
| GET | `/me/journeys/:id` | Journey detail (milestones, check-ins, encoded trail) |
| DELETE | `/me/journeys/:id` | Delete a journey |
| POST | `/me/journeys/:id/start` | Stamp `started_at` |
| POST | `/me/journeys/:id/finish` | Stamp `finished_at`; accepts the trail's `encoded_path` |
| POST/DELETE | `/me/journeys/:id/milestones(/:id)` | Add / remove a milestone |
| POST/DELETE | `/me/journeys/:id/checkins(/:id)` | Add / remove a check-in |
| POST | `/maps/:map_id/journeys` | Initialize a journey on a map |
| GET | `/me/chapters` | Owner's chapters (draft + published) |
| GET | `/me/chapters/:id` | Own chapter (draft or published) |
| PUT/DELETE | `/me/chapters/:id` | Update status/title/content, delete |
| POST | `/maps/:map_id/chapters` | Create a chapter (optionally recording a journey) |
| GET | `/chapters` | Timeline feed: published chapters on maps related to the user, `next_timestamp` pagination |
| GET | `/chapters/:id` | Read a chapter (published gated by map access; author sees own drafts) |
| GET | `/users/:user_id/chapters` | User's published chapters on maps the viewer can reference |
| GET | `/guest/chapters` | Latest published chapters on public maps |
| GET | `/guest/chapters/:id` | Read a published chapter on a public map |
| GET | `/guest/users/:user_id/chapters` | User's published chapters on public maps |

`GET /chapters` mirrors the reviews timeline (`GET /reviews`): `Chapter.feed_for(user)` scopes to published chapters on `Map.related_to(user)` (owned, coauthored, or bookmarked maps), paginated with `next_timestamp` like the review feed. Published chapters of other users are read through `GET /chapters/:id` (single chapter, `Chapter.readable_by` gated — this is how a coauthor reads a published chapter on a private map) and `/users/:user_id/chapters` (profile listing); guests use the guest endpoints (public maps only). Chapter show routes are top-level — `/chapters/:id` and `/guest/chapters/:id`, matching `/guest/reviews/:id` — because a chapter id alone identifies the resource; nesting under `/users/:user_id` or `/maps/:map_id` is kept only for collections, where the parent acts as a filter. The owner's editing surface reads through `/me/chapters/:id`. The "published on a map the viewer can reference" condition is one scope, `Chapter.referenceable_by` (matching the `Map.referenceable_by` / `Review.referenceable_by` vocabulary), composed by `readable_by` and the profile listing.

## Trail storage

The trail is a Google encoded polyline (`google.maps.geometry.encoding.encodePath` / `decodePath`) stored in a single `journeys.encoded_path` column, rather than one row per point. This keeps a long walk compact and lets the client submit the whole path in one request when it finishes the walk (the client holds the trail in localStorage until then). The Lexical `journey` node in a chapter carries the same `encoded_path` string. The trade-off is that per-point `recorded_at` is not retained; the time dimension lives on check-ins and on the journey's start/finish stamps.

## Map deletion

`journeys.map_id` and `chapters.map_id` are nullable: deleting a map nullifies the references instead of destroying the records, because journeys and chapters are the user's own history and writing, not the map's data. Serializers return `map: null` for orphaned records. A published chapter whose map was deleted is no longer map-referenceable, so it drops out of the public/guest listings and stays reachable only by its author under `/me` — the privacy-safe default.

## Visibility enforcement

A chapter surfaces its map's name and its spots (map-registered reviews), so its visibility follows the map the same way a `Review` does, combined with the chapter's own publish state:

- **Readable iff** the viewer can reference the chapter's map **and** it is `published`, **or** the viewer is the author. `Chapter.readable_by` derives map access from `Map.referenceable_by` (public, owned, or coauthored), so a published chapter on a private map reaches its author and the map's coauthors but 404s for everyone else. Guest endpoints use `Chapter.public_open` (published on public maps only).
- **Drafts stay author-only**, regardless of map access.
- Map access is evaluated per request rather than snapshotted, so flipping a map's privacy propagates to its chapters immediately (`Map.referenceable_by` is the single source of truth).
- The chapter content is served verbatim to every reader — it carries no private data. Check-in and trail timestamps live only on the author-only Journey and check-in records; the chapter's `spot` nodes omit `checked_in_at` and the `journey` node is an encoded polyline with no per-point time, so there is nothing to strip per viewer.
- Journeys are always author-only.

## Lifecycle enforcement

Milestone and check-in writes are accepted only on unfinished journeys (reached through the `unfinished` scope, so a finished or foreign journey is a 404). The trail is submitted with `finish`, which requires the journey to be started and not already finished. A finished journey cannot be mutated.

# Testing

- Local `bin/rails test` on MySQL 8.0 (matching CI): 201 runs, 0 failures. The one error, `NotificationTest#test_web_push_on_create`, is a pre-existing environment issue (no Google credentials locally) and fails identically on `master`.
- `db/schema.rb` regenerated on MySQL 8.0.

# Release and backward compatibility

The migrations only add four new tables and touch no existing table, so releasing this does not change the current qoodish-web behavior. Run the schema migration through the `qoodish-runner` Cloud Run Job before the frontend switches from localStorage to these endpoints. Milestone reordering and Firebase-uid → backend-user-id migration (open points noted in qoodish-web#1075) are out of scope for this first slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJS3V1zcUo6HDSwsiNKiL7