### PR TITLE
fix: guard follows/invites drops with if_exists

### DIFF
--- a/db/migrate/20260623010030_drop_follows.rb
+++ b/db/migrate/20260623010030_drop_follows.rb
@@ -1,6 +1,6 @@
 class DropFollows < ActiveRecord::Migration[7.2]
   def change
-    drop_table :follows, force: :cascade do |t|
+    drop_table :follows, if_exists: true, force: :cascade do |t|
       t.string "followable_type", null: false
       t.bigint "followable_id", null: false
       t.string "follower_type", null: false

--- a/db/migrate/20260623010032_drop_invites.rb
+++ b/db/migrate/20260623010032_drop_invites.rb
@@ -1,6 +1,6 @@
 class DropInvites < ActiveRecord::Migration[7.2]
   def change
-    drop_table :invites, force: :cascade do |t|
+    drop_table :invites, if_exists: true, force: :cascade do |t|
       t.string "invitable_type"
       t.bigint "invitable_id"
       t.string "sender_type"


### PR DESCRIPTION
# Summary

Make the `drop_follows` (20260623010030) and `drop_invites` (20260623010032) migrations idempotent by adding `if_exists: true` to their `drop_table` calls.

# Motivation

Running `db:migrate` on the dev environment fails with `Unknown table 'follows'` at `20260623010030_drop_follows`. On that database the `follows` and `invites` tables are already gone, yet the two drop migrations are still recorded as pending in `schema_migrations`, so `db:migrate` tries to drop tables that no longer exist.

These two migrations are the only path that drops `follows`/`invites`, and the backfill task never dropped them, so the tables were removed while the matching `schema_migrations` rows were not recorded — most consistent with an earlier iteration of this drop running under a different migration version before the final timestamps were settled. A backup restore or a manual drop would leave the same state. In every case the fix is the same: the migration must tolerate the table already being absent.

# Changes

- Add `if_exists: true` to `drop_table :follows` and `drop_table :invites`, so each migration drops the table where it still exists and records itself as a no-op where the table is already gone.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017tkTLuZ7b2QzcDuLG8jKno)_