### PR TITLE
feat: attach images to journey checkins

### DIFF
--- a/app/controllers/maps/journeys_controller.rb
+++ b/app/controllers/maps/journeys_controller.rb
@@ -9,7 +9,7 @@ module Maps
 
       ActiveRecord::Associations::Preloader.new(
         records: [@journey],
-        associations: [:map, :milestones, :checkins, :chapter]
+        associations: [:map, :milestones, { checkins: :images }, :chapter]
       ).call
     end
   end

--- a/app/controllers/me/journeys/checkins_controller.rb
+++ b/app/controllers/me/journeys/checkins_controller.rb
@@ -7,13 +7,26 @@ module Me
         journey = current_user.journeys.unfinished.find_by!(id: params[:journey_id])
         review = current_user.referenceable_reviews.find_by!(id: params[:review_id])
 
-        @checkin = journey.checkins.create!(review: review)
+        @checkin = journey.checkins.create!(checkin_params.merge(review: review))
+      end
+
+      def update
+        journey = current_user.journeys.find_by!(id: params[:journey_id])
+
+        @checkin = journey.checkins.find_by!(id: params[:id])
+        @checkin.update!(checkin_params)
       end
 
       def destroy
         journey = current_user.journeys.unfinished.find_by!(id: params[:journey_id])
 
         journey.checkins.find_by!(id: params[:id]).destroy!
+      end
+
+      private
+
+      def checkin_params
+        params.permit(image_ids: [])
       end
     end
   end

--- a/app/controllers/me/journeys/checkins_controller.rb
+++ b/app/controllers/me/journeys/checkins_controller.rb
@@ -4,7 +4,7 @@ module Me
       before_action :authenticate_user!
 
       def create
-        journey = current_user.journeys.unfinished.find_by!(id: params[:journey_id])
+        journey = current_user.journeys.find_by!(id: params[:journey_id])
         review = current_user.referenceable_reviews.find_by!(id: params[:review_id])
 
         @checkin = journey.checkins.create!(checkin_params.merge(review: review))
@@ -18,7 +18,7 @@ module Me
       end
 
       def destroy
-        journey = current_user.journeys.unfinished.find_by!(id: params[:journey_id])
+        journey = current_user.journeys.find_by!(id: params[:journey_id])
 
         journey.checkins.find_by!(id: params[:id]).destroy!
       end
@@ -26,7 +26,7 @@ module Me
       private
 
       def checkin_params
-        params.permit(:note, image_ids: [])
+        params.permit(:note, :checked_in_at, image_ids: [])
       end
     end
   end

--- a/app/controllers/me/journeys/checkins_controller.rb
+++ b/app/controllers/me/journeys/checkins_controller.rb
@@ -26,7 +26,7 @@ module Me
       private
 
       def checkin_params
-        params.permit(image_ids: [])
+        params.permit(:note, image_ids: [])
       end
     end
   end

--- a/app/controllers/me/journeys_controller.rb
+++ b/app/controllers/me/journeys_controller.rb
@@ -12,7 +12,7 @@ module Me
     def show
       @journey = current_user
                  .journeys
-                 .preload(:map, :milestones, :checkins, :chapter)
+                 .preload(:map, :milestones, { checkins: :images }, :chapter)
                  .find_by!(id: params[:id])
     end
 
@@ -39,7 +39,7 @@ module Me
     def preload_journey_for_serialization
       ActiveRecord::Associations::Preloader.new(
         records: [@journey],
-        associations: [:map, :milestones, :checkins, :chapter]
+        associations: [:map, :milestones, { checkins: :images }, :chapter]
       ).call
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
     current_user.reviews.preload(:images, :votes).load
     current_user.maps.preload(:images, :coauthorships, :bookmarks, :coauthorship_invitations, :votes,
                               reviews: [:images, :votes]).load
-    current_user.journeys.preload(:milestones, :checkins).load
+    current_user.journeys.preload(:milestones, checkins: :images).load
     current_user.destroy!
   end
 

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -7,7 +7,7 @@ class Journey < ApplicationRecord
   belongs_to :map, optional: true
   has_many :milestones, -> { order(:position) }, dependent: :destroy, inverse_of: :journey
   has_many :checkins,
-           -> { order(Arel.sql('COALESCE(journey_checkins.checked_in_at, journey_checkins.created_at)'), :id) },
+           -> { order(:checked_in_at, :id) },
            class_name: 'JourneyCheckin',
            dependent: :destroy,
            inverse_of: :journey

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -7,7 +7,7 @@ class Journey < ApplicationRecord
   belongs_to :map, optional: true
   has_many :milestones, -> { order(:position) }, dependent: :destroy, inverse_of: :journey
   has_many :checkins,
-           -> { order(:id) },
+           -> { order(Arel.sql('COALESCE(journey_checkins.checked_in_at, journey_checkins.created_at)'), :id) },
            class_name: 'JourneyCheckin',
            dependent: :destroy,
            inverse_of: :journey

--- a/app/models/journey_checkin.rb
+++ b/app/models/journey_checkin.rb
@@ -31,12 +31,6 @@ class JourneyCheckin < ApplicationRecord
             }
   validate :checked_in_at_must_be_within_journey_period, if: :checked_in_at_changed?
 
-  # Nil means the row predates the checked_in_at column, where creation time
-  # and visit time were the same thing.
-  def checked_in_at
-    super || created_at
-  end
-
   private
 
   def remove_carriage_return

--- a/app/models/journey_checkin.rb
+++ b/app/models/journey_checkin.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 MAX_IMAGE_COUNT_PER_CHECKIN = 4
+MAX_CHECKIN_NOTE_LENGTH = 500
 
 class JourneyCheckin < ApplicationRecord
   include ReviewSnapshot
@@ -10,10 +11,17 @@ class JourneyCheckin < ApplicationRecord
 
   delegate :user_id, to: :journey
 
+  before_validation :remove_carriage_return
+
   validates :review_id,
             uniqueness: {
               scope: :journey_id,
               message: I18n.t('messages.api.duplicate_checkin')
+            }
+  validates :note,
+            length: {
+              maximum: MAX_CHECKIN_NOTE_LENGTH,
+              message: I18n.t('messages.api.checkin_note_exceeded')
             }
   validates :images,
             length: {
@@ -23,6 +31,10 @@ class JourneyCheckin < ApplicationRecord
   validate :journey_must_be_in_progress, on: :create
 
   private
+
+  def remove_carriage_return
+    note.delete!("\r") if note.present?
+  end
 
   def journey_must_be_in_progress
     return if journey.blank?

--- a/app/models/journey_checkin.rb
+++ b/app/models/journey_checkin.rb
@@ -1,14 +1,24 @@
 # frozen_string_literal: true
 
+MAX_IMAGE_COUNT_PER_CHECKIN = 4
+
 class JourneyCheckin < ApplicationRecord
   include ReviewSnapshot
 
   belongs_to :journey
+  has_many :images, as: :imageable, dependent: :destroy
+
+  delegate :user_id, to: :journey
 
   validates :review_id,
             uniqueness: {
               scope: :journey_id,
               message: I18n.t('messages.api.duplicate_checkin')
+            }
+  validates :images,
+            length: {
+              maximum: MAX_IMAGE_COUNT_PER_CHECKIN,
+              message: I18n.t('messages.api.images_per_checkin_reached_limit')
             }
   validate :journey_must_be_in_progress, on: :create
 

--- a/app/models/journey_checkin.rb
+++ b/app/models/journey_checkin.rb
@@ -12,6 +12,7 @@ class JourneyCheckin < ApplicationRecord
   delegate :user_id, to: :journey
 
   before_validation :remove_carriage_return
+  before_validation :set_default_checked_in_at, on: :create
 
   validates :review_id,
             uniqueness: {
@@ -28,7 +29,13 @@ class JourneyCheckin < ApplicationRecord
               maximum: MAX_IMAGE_COUNT_PER_CHECKIN,
               message: I18n.t('messages.api.images_per_checkin_reached_limit')
             }
-  validate :journey_must_be_in_progress, on: :create
+  validate :checked_in_at_must_be_within_journey_period, if: :checked_in_at_changed?
+
+  # Nil means the row predates the checked_in_at column, where creation time
+  # and visit time were the same thing.
+  def checked_in_at
+    super || created_at
+  end
 
   private
 
@@ -36,10 +43,21 @@ class JourneyCheckin < ApplicationRecord
     note.delete!("\r") if note.present?
   end
 
-  def journey_must_be_in_progress
-    return if journey.blank?
-    return if journey.in_progress?
+  def set_default_checked_in_at
+    self.checked_in_at ||= Time.current
+  end
 
-    errors.add(:base, I18n.t('messages.api.journey_not_in_progress'))
+  def checked_in_at_must_be_within_journey_period
+    return if journey.blank?
+
+    unless journey.started?
+      errors.add(:base, I18n.t('messages.api.journey_not_started'))
+      return
+    end
+
+    upper_bound = journey.finished_at || Time.current
+    return if checked_in_at.present? && checked_in_at.between?(journey.started_at, upper_bound)
+
+    errors.add(:checked_in_at, I18n.t('messages.api.checkin_time_outside_journey_period'))
   end
 end

--- a/app/views/me/journeys/checkins/update.jbuilder
+++ b/app/views/me/journeys/checkins/update.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'partials/journey_checkin', journey_checkin: @checkin

--- a/app/views/partials/_chapter.jbuilder
+++ b/app/views/partials/_chapter.jbuilder
@@ -7,6 +7,7 @@ json.content chapter.content
 json.author do
   json.id chapter.user.id
   json.name chapter.user.name
+  json.biography chapter.user.biography
   json.image chapter.user.image_variants
   json.image_url chapter.user.image_url
 end

--- a/app/views/partials/_journey_checkin.jbuilder
+++ b/app/views/partials/_journey_checkin.jbuilder
@@ -15,4 +15,4 @@ json.images journey_checkin.images do |image|
   json.hero variants[:hero]
   json.ogp variants[:ogp]
 end
-json.checked_in_at journey_checkin.created_at
+json.checked_in_at journey_checkin.checked_in_at

--- a/app/views/partials/_journey_checkin.jbuilder
+++ b/app/views/partials/_journey_checkin.jbuilder
@@ -5,4 +5,13 @@ json.spot do
   json.latitude journey_checkin.lat
   json.longitude journey_checkin.lng
 end
+json.images journey_checkin.images do |image|
+  variants = image.variants
+  json.id image.id
+  json.url image.url
+  json.avatar variants[:avatar]
+  json.card variants[:card]
+  json.hero variants[:hero]
+  json.ogp variants[:ogp]
+end
 json.checked_in_at journey_checkin.created_at

--- a/app/views/partials/_journey_checkin.jbuilder
+++ b/app/views/partials/_journey_checkin.jbuilder
@@ -5,6 +5,7 @@ json.spot do
   json.latitude journey_checkin.lat
   json.longitude journey_checkin.lng
 end
+json.note journey_checkin.note
 json.images journey_checkin.images do |image|
   variants = image.variants
   json.id image.id

--- a/app/views/partials/guest/_chapter.jbuilder
+++ b/app/views/partials/guest/_chapter.jbuilder
@@ -7,6 +7,7 @@ json.content chapter.content
 json.author do
   json.id chapter.user.id
   json.name chapter.user.name
+  json.biography chapter.user.biography
   json.image chapter.user.image_variants
   json.image_url chapter.user.image_url
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
       duplicate_milestone: The pin is already added as a milestone.
       duplicate_checkin: The journey has already checked in at this pin.
       review_not_on_journey_map: The pin does not belong to the map of the journey.
+      images_per_checkin_reached_limit: "The limit of images per checkin has been reached."
 
       chapter_title_required: Chapter title is required.
       chapter_title_exceed: "Chapter title is too long. (Max: 100)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,7 @@ en:
       review_not_on_journey_map: The pin does not belong to the map of the journey.
       images_per_checkin_reached_limit: "The limit of images per checkin has been reached."
       checkin_note_exceeded: "The note is too long. (Max: 500)"
+      checkin_time_outside_journey_period: The checkin time is outside the journey period.
 
       chapter_title_required: Chapter title is required.
       chapter_title_exceed: "Chapter title is too long. (Max: 100)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
       duplicate_checkin: The journey has already checked in at this pin.
       review_not_on_journey_map: The pin does not belong to the map of the journey.
       images_per_checkin_reached_limit: "The limit of images per checkin has been reached."
+      checkin_note_exceeded: "The note is too long. (Max: 500)"
 
       chapter_title_required: Chapter title is required.
       chapter_title_exceed: "Chapter title is too long. (Max: 100)"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,6 +43,7 @@ ja:
       review_not_on_journey_map: このピンは旅のマップに属していません。
       images_per_checkin_reached_limit: "チェックインごとの画像数の上限に達しました。"
       checkin_note_exceeded: "メモが長すぎます。(最大: 500 文字)"
+      checkin_time_outside_journey_period: チェックイン時刻が旅の期間外です。
 
       chapter_title_required: チャプターのタイトルを入力してください。
       chapter_title_exceed: "チャプターのタイトルが長すぎます。(最大: 100 文字)"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -42,6 +42,7 @@ ja:
       duplicate_checkin: このピンには既にチェックイン済みです。
       review_not_on_journey_map: このピンは旅のマップに属していません。
       images_per_checkin_reached_limit: "チェックインごとの画像数の上限に達しました。"
+      checkin_note_exceeded: "メモが長すぎます。(最大: 500 文字)"
 
       chapter_title_required: チャプターのタイトルを入力してください。
       chapter_title_exceed: "チャプターのタイトルが長すぎます。(最大: 100 文字)"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -41,6 +41,7 @@ ja:
       duplicate_milestone: このピンは既にマイルストーンに追加されています。
       duplicate_checkin: このピンには既にチェックイン済みです。
       review_not_on_journey_map: このピンは旅のマップに属していません。
+      images_per_checkin_reached_limit: "チェックインごとの画像数の上限に達しました。"
 
       chapter_title_required: チャプターのタイトルを入力してください。
       chapter_title_exceed: "チャプターのタイトルが長すぎます。(最大: 100 文字)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
       end
       scope module: :journeys do
         resources :milestones, only: %i[create destroy]
-        resources :checkins, only: %i[create destroy]
+        resources :checkins, only: %i[create update destroy]
       end
     end
     resources :chapters, only: %i[index show update destroy]

--- a/db/migrate/20260719125538_add_note_to_journey_checkins.rb
+++ b/db/migrate/20260719125538_add_note_to_journey_checkins.rb
@@ -1,0 +1,5 @@
+class AddNoteToJourneyCheckins < ActiveRecord::Migration[7.2]
+  def change
+    add_column :journey_checkins, :note, :text
+  end
+end

--- a/db/migrate/20260719172202_add_checked_in_at_to_journey_checkins.rb
+++ b/db/migrate/20260719172202_add_checked_in_at_to_journey_checkins.rb
@@ -1,0 +1,5 @@
+class AddCheckedInAtToJourneyCheckins < ActiveRecord::Migration[7.2]
+  def change
+    add_column :journey_checkins, :checked_in_at, :datetime
+  end
+end

--- a/db/migrate/20260720102542_change_journey_checkins_checked_in_at_null.rb
+++ b/db/migrate/20260720102542_change_journey_checkins_checked_in_at_null.rb
@@ -1,0 +1,5 @@
+class ChangeJourneyCheckinsCheckedInAtNull < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :journey_checkins, :checked_in_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_19_172202) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_20_102542) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "map_id", null: false
     t.bigint "user_id", null: false
@@ -111,7 +111,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_19_172202) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "note"
-    t.datetime "checked_in_at"
+    t.datetime "checked_in_at", null: false
     t.index ["journey_id", "review_id"], name: "index_journey_checkins_on_journey_id_and_review_id", unique: true
     t.index ["review_id"], name: "index_journey_checkins_on_review_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_13_043049) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_19_125538) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "map_id", null: false
     t.bigint "user_id", null: false
@@ -110,6 +110,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_13_043049) do
     t.decimal "longitude", precision: 16, scale: 6, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "note"
     t.index ["journey_id", "review_id"], name: "index_journey_checkins_on_journey_id_and_review_id", unique: true
     t.index ["review_id"], name: "index_journey_checkins_on_review_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_19_125538) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_19_172202) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "map_id", null: false
     t.bigint "user_id", null: false
@@ -111,6 +111,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_19_125538) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "note"
+    t.datetime "checked_in_at"
     t.index ["journey_id", "review_id"], name: "index_journey_checkins_on_journey_id_and_review_id", unique: true
     t.index ["review_id"], name: "index_journey_checkins_on_review_id"
   end

--- a/lib/tasks/backfill_journey_checkin_checked_in_at.rb
+++ b/lib/tasks/backfill_journey_checkin_checked_in_at.rb
@@ -3,6 +3,8 @@
 # Populates checked_in_at added by 20260719172202_add_checked_in_at_to_journey_checkins.
 # Rows created before the column existed treat creation time as the visit time,
 # so created_at is copied verbatim.
+# Run between that migration and 20260720102542_change_journey_checkins_checked_in_at_null,
+# which assumes no NULL rows remain.
 
 updated = JourneyCheckin.where(checked_in_at: nil).update_all('checked_in_at = created_at')
 Rails.logger.info("Backfill complete: #{updated} journey checkins")

--- a/lib/tasks/backfill_journey_checkin_checked_in_at.rb
+++ b/lib/tasks/backfill_journey_checkin_checked_in_at.rb
@@ -1,0 +1,8 @@
+# bin/rails runner lib/tasks/backfill_journey_checkin_checked_in_at.rb
+#
+# Populates checked_in_at added by 20260719172202_add_checked_in_at_to_journey_checkins.
+# Rows created before the column existed treat creation time as the visit time,
+# so created_at is copied verbatim.
+
+updated = JourneyCheckin.where(checked_in_at: nil).update_all('checked_in_at = created_at')
+Rails.logger.info("Backfill complete: #{updated} journey checkins")

--- a/test/controllers/chapters_controller_test.rb
+++ b/test/controllers/chapters_controller_test.rb
@@ -46,6 +46,7 @@ class ChaptersControllerTest < ActionDispatch::IntegrationTest
 
     assert_not res['editable']
     assert_equal chapters(:my_published).content['root'], res['content']['root']
+    assert_equal users(:me).biography, res['author']['biography']
   end
 
   test 'show a published chapter on a private map as a coauthor should be success' do

--- a/test/controllers/guest/chapters_controller_test.rb
+++ b/test/controllers/guest/chapters_controller_test.rb
@@ -25,6 +25,7 @@ class Guest::ChaptersControllerTest < ActionDispatch::IntegrationTest
     assert_equal chapters(:my_published).id, res['id']
     assert_not res.key?('editable')
     assert_equal chapters(:my_published).content['root'], res['content']['root']
+    assert_equal users(:me).biography, res['author']['biography']
   end
 
   test 'show a draft chapter should raise not found error' do

--- a/test/controllers/me/journeys/checkins_controller_test.rb
+++ b/test/controllers/me/journeys/checkins_controller_test.rb
@@ -49,6 +49,113 @@ class Me::Journeys::CheckinsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test 'check in with image_ids attaches owned images' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/checkin-create/public'
+    )
+
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_in_progress).id}/checkins",
+           params: { review_id: reviews(:private_you).id, image_ids: [image.id] },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal [image.id], res['images'].map { |i| i['id'] }
+    assert_equal [image.id], JourneyCheckin.find(res['id']).image_ids
+  end
+
+  test 'check in with too many image_ids should raise unprocessable error' do
+    image_ids = Array.new(5) do |i|
+      users(:me).owned_images.create!(
+        url: "https://imagedelivery.net/mockhash/checkin-limit-#{i}/public"
+      ).id
+    end
+
+    assert_no_difference 'JourneyCheckin.count' do
+      stub_google_auth(users(:me)) do
+        post "/me/journeys/#{journeys(:my_in_progress).id}/checkins",
+             params: { review_id: reviews(:private_you).id, image_ids: image_ids },
+             headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'update with image_ids attaches images to a finished journey checkin' do
+    image = users(:me).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/checkin-update/public'
+    )
+    checkin = journey_checkins(:my_finished_public_one)
+
+    stub_google_auth(users(:me)) do
+      put "/me/journeys/#{journeys(:my_finished).id}/checkins/#{checkin.id}",
+          params: { image_ids: [image.id] },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+    assert_equal [image.id], checkin.reload.image_ids
+
+    res = JSON.parse(@response.body)
+
+    assert_equal [image.id], res['images'].map { |i| i['id'] }
+  end
+
+  test 'update with image_ids destroys removed images' do
+    checkin = journey_checkins(:my_finished_public_one)
+    kept = checkin.images.create!(
+      user: users(:me),
+      url: 'https://imagedelivery.net/mockhash/checkin-kept/public'
+    )
+    removed = checkin.images.create!(
+      user: users(:me),
+      url: 'https://imagedelivery.net/mockhash/checkin-removed/public'
+    )
+
+    stub_google_auth(users(:me)) do
+      stub_cloudflare_images do
+        put "/me/journeys/#{journeys(:my_finished).id}/checkins/#{checkin.id}",
+            params: { image_ids: [kept.id] },
+            headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+    assert_equal [kept.id], checkin.reload.image_ids
+    assert_nil Image.find_by(id: removed.id)
+  end
+
+  test 'update rejects image_ids that belong to another user' do
+    foreign_image = users(:you).owned_images.create!(
+      url: 'https://imagedelivery.net/mockhash/checkin-foreign/public'
+    )
+    checkin = journey_checkins(:my_finished_public_one)
+
+    stub_google_auth(users(:me)) do
+      put "/me/journeys/#{journeys(:my_finished).id}/checkins/#{checkin.id}",
+          params: { image_ids: [foreign_image.id] },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+    assert_empty checkin.reload.image_ids
+  end
+
+  test 'update a checkin on a journey of another user should raise not found error' do
+    stub_google_auth(users(:me)) do
+      put "/me/journeys/#{journeys(:you_in_progress).id}/checkins/#{journey_checkins(:my_finished_public_one).id}",
+          params: { image_ids: [] },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
   test 'remove a checkin from an unfinished journey should be success' do
     assert_difference 'JourneyCheckin.count', -1 do
       stub_google_auth(users(:me)) do

--- a/test/controllers/me/journeys/checkins_controller_test.rb
+++ b/test/controllers/me/journeys/checkins_controller_test.rb
@@ -49,14 +49,18 @@ class Me::Journeys::CheckinsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test 'check in with image_ids attaches owned images' do
+  test 'check in with image_ids and note attaches them' do
     image = users(:me).owned_images.create!(
       url: 'https://imagedelivery.net/mockhash/checkin-create/public'
     )
 
     stub_google_auth(users(:me)) do
       post "/me/journeys/#{journeys(:my_in_progress).id}/checkins",
-           params: { review_id: reviews(:private_you).id, image_ids: [image.id] },
+           params: {
+             review_id: reviews(:private_you).id,
+             image_ids: [image.id],
+             note: 'First visit with friends'
+           },
            headers: { 'Authorization': 'Bearer dummytoken' }
     end
 
@@ -66,6 +70,7 @@ class Me::Journeys::CheckinsControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal [image.id], res['images'].map { |i| i['id'] }
     assert_equal [image.id], JourneyCheckin.find(res['id']).image_ids
+    assert_equal 'First visit with friends', res['note']
   end
 
   test 'check in with too many image_ids should raise unprocessable error' do
@@ -86,7 +91,7 @@ class Me::Journeys::CheckinsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
   end
 
-  test 'update with image_ids attaches images to a finished journey checkin' do
+  test 'update with image_ids and note edits a finished journey checkin' do
     image = users(:me).owned_images.create!(
       url: 'https://imagedelivery.net/mockhash/checkin-update/public'
     )
@@ -94,16 +99,30 @@ class Me::Journeys::CheckinsControllerTest < ActionDispatch::IntegrationTest
 
     stub_google_auth(users(:me)) do
       put "/me/journeys/#{journeys(:my_finished).id}/checkins/#{checkin.id}",
-          params: { image_ids: [image.id] },
+          params: { image_ids: [image.id], note: "Great view\r\nfrom the terrace" },
           headers: { 'Authorization': 'Bearer dummytoken' }
     end
 
     assert_response :success
     assert_equal [image.id], checkin.reload.image_ids
+    assert_equal "Great view\nfrom the terrace", checkin.note
 
     res = JSON.parse(@response.body)
 
     assert_equal [image.id], res['images'].map { |i| i['id'] }
+  end
+
+  test 'update with a too long note should raise unprocessable error' do
+    checkin = journey_checkins(:my_finished_public_one)
+
+    stub_google_auth(users(:me)) do
+      put "/me/journeys/#{journeys(:my_finished).id}/checkins/#{checkin.id}",
+          params: { note: 'a' * 501 },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+    assert_nil checkin.reload.note
   end
 
   test 'update with image_ids destroys removed images' do

--- a/test/controllers/me/journeys/checkins_controller_test.rb
+++ b/test/controllers/me/journeys/checkins_controller_test.rb
@@ -130,12 +130,12 @@ class Me::Journeys::CheckinsControllerTest < ActionDispatch::IntegrationTest
 
     stub_google_auth(users(:me)) do
       put "/me/journeys/#{journeys(:my_finished).id}/checkins/#{checkin.id}",
-          params: { checked_in_at: '2026-06-01 10:30:00' },
+          params: { checked_in_at: '2026-06-01 11:15:00' },
           headers: { 'Authorization': 'Bearer dummytoken' }
     end
 
     assert_response :success
-    assert_equal Time.zone.parse('2026-06-01 10:30:00'), checkin.reload.checked_in_at
+    assert_equal Time.zone.parse('2026-06-01 11:15:00'), checkin.reload.checked_in_at
   end
 
   test 'update checked_in_at outside the journey period should raise unprocessable error' do

--- a/test/controllers/me/journeys/checkins_controller_test.rb
+++ b/test/controllers/me/journeys/checkins_controller_test.rb
@@ -91,6 +91,76 @@ class Me::Journeys::CheckinsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_content
   end
 
+  test 'retroactive check in on a finished journey should be success' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_finished).id}/checkins",
+           params: { review_id: reviews(:public_two).id, checked_in_at: '2026-06-01 11:00:00' },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal Time.zone.parse('2026-06-01 11:00:00'), Time.zone.parse(res['checked_in_at'])
+  end
+
+  test 'check in on a finished journey without checked_in_at should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_finished).id}/checkins",
+           params: { review_id: reviews(:public_two).id },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'check in outside the journey period should raise unprocessable error' do
+    stub_google_auth(users(:me)) do
+      post "/me/journeys/#{journeys(:my_finished).id}/checkins",
+           params: { review_id: reviews(:public_two).id, checked_in_at: '2026-06-01 09:00:00' },
+           headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'update checked_in_at within the journey period should be success' do
+    checkin = journey_checkins(:my_finished_public_one)
+
+    stub_google_auth(users(:me)) do
+      put "/me/journeys/#{journeys(:my_finished).id}/checkins/#{checkin.id}",
+          params: { checked_in_at: '2026-06-01 10:30:00' },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+    assert_equal Time.zone.parse('2026-06-01 10:30:00'), checkin.reload.checked_in_at
+  end
+
+  test 'update checked_in_at outside the journey period should raise unprocessable error' do
+    checkin = journey_checkins(:my_finished_public_one)
+
+    stub_google_auth(users(:me)) do
+      put "/me/journeys/#{journeys(:my_finished).id}/checkins/#{checkin.id}",
+          params: { checked_in_at: '2026-06-01 13:00:00' },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+  end
+
+  test 'remove a checkin from a finished journey should be success' do
+    assert_difference 'JourneyCheckin.count', -1 do
+      stub_google_auth(users(:me)) do
+        delete "/me/journeys/#{journeys(:my_finished).id}/checkins/#{journey_checkins(:my_finished_public_one).id}",
+               headers: { 'Authorization': 'Bearer dummytoken' }
+      end
+    end
+
+    assert_response :success
+  end
+
   test 'update with image_ids and note edits a finished journey checkin' do
     image = users(:me).owned_images.create!(
       url: 'https://imagedelivery.net/mockhash/checkin-update/public'

--- a/test/fixtures/journey_checkins.yml
+++ b/test/fixtures/journey_checkins.yml
@@ -4,6 +4,7 @@ my_in_progress_private:
   name: This is a name
   latitude: 35.681382
   longitude: 139.766084
+  checked_in_at: 2026-07-01 11:00:00
 
 my_finished_public_one:
   journey: my_finished
@@ -11,3 +12,4 @@ my_finished_public_one:
   name: This is a name
   latitude: 35.681382
   longitude: 139.766084
+  checked_in_at: 2026-06-01 10:30:00

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,6 +2,7 @@ me:
   name: watame
   email: watame@qoodish.com
   uid: 1234abcde
+  biography: This is a biography
 
 you:
   name: okayu

--- a/test/models/journey_checkin_test.rb
+++ b/test/models/journey_checkin_test.rb
@@ -19,6 +19,25 @@ class JourneyCheckinTest < ActiveSupport::TestCase
     assert_not checkin.valid?
   end
 
+  test 'checkin on a finished journey with a visit time in the period is created' do
+    checkin = journeys(:my_finished).checkins.create!(
+      review: reviews(:public_two),
+      checked_in_at: '2026-06-01 11:00:00'
+    )
+
+    assert_predicate checkin, :persisted?
+  end
+
+  test 'checkins are ordered by visit time' do
+    journey = journeys(:my_finished)
+    retroactive = journey.checkins.create!(
+      review: reviews(:public_two),
+      checked_in_at: '2026-06-01 11:00:00'
+    )
+
+    assert_equal retroactive.id, journey.checkins.reload.first.id
+  end
+
   test 'same review cannot be checked in twice on a journey' do
     checkin = journeys(:my_in_progress).checkins.build(review: reviews(:private))
 

--- a/test/models/journey_checkin_test.rb
+++ b/test/models/journey_checkin_test.rb
@@ -32,7 +32,7 @@ class JourneyCheckinTest < ActiveSupport::TestCase
     journey = journeys(:my_finished)
     retroactive = journey.checkins.create!(
       review: reviews(:public_two),
-      checked_in_at: '2026-06-01 11:00:00'
+      checked_in_at: '2026-06-01 10:15:00'
     )
 
     assert_equal retroactive.id, journey.checkins.reload.first.id


### PR DESCRIPTION
# Summary

Turns journey checkins into full visit records. A checkin now carries photos (`image_ids`), a note, and its own visit time (`checked_in_at`), and can be created, edited, and deleted after the journey has finished. A new `PATCH /me/journeys/:journey_id/checkins/:id` endpoint handles the editing. Also fixes the chapter payload so the author block includes `biography`.

# Motivation

Checkins could only reference a pin. Photos taken at the spot could not be kept with the journey, and there was no place to write about the visit itself — review comments are used for describing the spot. The note captures the moment of the visit and serves as source material when composing the chapter body afterwards.

Checkins also conflated the record time with the visit time (`checked_in_at` was serialized from `created_at`), which is why creation had to be restricted to in-progress journeys. Following the bitemporal split Google Maps Timeline uses for its editable place visits, `checked_in_at` becomes an independent column: a visit missed during the trip can be added afterwards at its actual time, as long as that time falls within the journey period.

The chapter detail page renders author details, but the serialized author block omitted `biography`, so it always displayed empty.

# Changes

- `JourneyCheckin` gains a polymorphic `images` association with the same 4-image limit and ownership validation as review images; the checkin exposes `user_id` through its journey so the existing `Image` owner validation applies.
- A `note` text column is added (max 500 characters, matching review comments; carriage returns are stripped the same way).
- A `checked_in_at` datetime column (NOT NULL) replaces `created_at` as the serialized visit time. It defaults to the current time on creation, must fall within the journey period (`started_at` to `finished_at`, or now while in progress), and is editable through the update endpoint. Checkins are ordered by visit time so retroactive entries land in the right place.
- Checkin creation and deletion no longer require an in-progress journey; the visit-time validation replaces that restriction. On a finished journey `checked_in_at` is effectively required, since the default (now) falls outside the period.
- Checkin serialization includes `note` and an `images` array with Cloudflare variant URLs.
- Removing an id from `image_ids` (or deleting a checkin) destroys the image, including the Cloudflare object — the same semantics as review images.
- The author block in both authenticated and guest chapter serializations now includes `biography`.

The API changes are additive (new optional parameters, new endpoint, new response fields; `checked_in_at` keeps its name and format), so the release stays backward compatible with the current qoodish-web version.

# Release procedure

The PR includes three migrations (`AddNoteToJourneyCheckins`, `AddCheckedInAtToJourneyCheckins`, `ChangeJourneyCheckinsCheckedInAtNull`) and a backfill script. The NOT NULL migration requires that no NULL `checked_in_at` rows remain, so environments with existing checkin rows must run the backfill between the migrations.

**dev** (has existing `journey_checkins` rows) — run through the `qoodish-runner` Cloud Run Job, before shifting traffic:

1. `bin/rails db:migrate VERSION=20260719172202` (adds `note` and `checked_in_at`)
2. `bin/rails runner lib/tasks/backfill_journey_checkin_checked_in_at.rb` (copies `created_at` into `checked_in_at`)
3. `bin/rails db:migrate` (applies NOT NULL)

**production** (the `journey_checkins` table is not released yet) — a plain `db:migrate` before shifting traffic is sufficient: the table is created and constrained within the same run, so no row can hold NULL and the backfill is a no-op.

# Testing

- Controller tests cover attaching images and a note on create, retroactive creation on a finished journey (success, missing time, and out-of-period time), editing images, note, and visit time after the journey finished, deletion on a finished journey, the image and note limits, and ownership rejection.
- Model tests cover the visit-time validation and visit-time ordering of retroactive entries.
- Chapter show tests assert `biography` in the author block for authenticated and guest responses.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012dTmS4RPdWm5Kb67ZRDJea