### PR TITLE
feat: encrypt journey trajectory at rest

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -13,6 +13,8 @@ class Journey < ApplicationRecord
            inverse_of: :journey
   has_one :chapter, dependent: :nullify
 
+  encrypts :encoded_path
+
   validates :user_id,
             presence: true
   validates :map,

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,9 @@ module Qoodish
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.active_record.encryption.primary_key = ENV['AR_ENCRYPTION_PRIMARY_KEY']
+    config.active_record.encryption.key_derivation_salt = ENV['AR_ENCRYPTION_KEY_DERIVATION_SALT']
+    config.active_record.encryption.support_unencrypted_data = false
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,6 +62,10 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
+  config.active_record.encryption.primary_key = 'test_ar_encryption_primary_key_0'
+  config.active_record.encryption.key_derivation_salt = 'test_ar_encryption_key_derive_salt'
+  config.active_record.encryption.encrypt_fixtures = true
+
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true

--- a/run/dev/api/base.yaml
+++ b/run/dev/api/base.yaml
@@ -99,6 +99,16 @@ spec:
                 secretKeyRef:
                   name: QOODISH_API_DB_USER
                   key: latest
+            - name: AR_ENCRYPTION_PRIMARY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: QOODISH_API_AR_ENCRYPTION_PRIMARY_KEY
+                  key: latest
+            - name: AR_ENCRYPTION_KEY_DERIVATION_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: QOODISH_API_AR_ENCRYPTION_KEY_DERIVATION_SALT
+                  key: latest
         - image: "us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.129.0"
           name: otelcol
           args:

--- a/run/dev/runner/base.yaml
+++ b/run/dev/runner/base.yaml
@@ -74,3 +74,13 @@ spec:
                     secretKeyRef:
                       name: QOODISH_API_DB_USER
                       key: latest
+                - name: AR_ENCRYPTION_PRIMARY_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: QOODISH_API_AR_ENCRYPTION_PRIMARY_KEY
+                      key: latest
+                - name: AR_ENCRYPTION_KEY_DERIVATION_SALT
+                  valueFrom:
+                    secretKeyRef:
+                      name: QOODISH_API_AR_ENCRYPTION_KEY_DERIVATION_SALT
+                      key: latest

--- a/run/prod/api/base.yaml
+++ b/run/prod/api/base.yaml
@@ -98,6 +98,16 @@ spec:
                 secretKeyRef:
                   name: QOODISH_API_DB_USER
                   key: latest
+            - name: AR_ENCRYPTION_PRIMARY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: QOODISH_API_AR_ENCRYPTION_PRIMARY_KEY
+                  key: latest
+            - name: AR_ENCRYPTION_KEY_DERIVATION_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: QOODISH_API_AR_ENCRYPTION_KEY_DERIVATION_SALT
+                  key: latest
         - image: "us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.129.0"
           name: otelcol
           args:

--- a/run/prod/runner/base.yaml
+++ b/run/prod/runner/base.yaml
@@ -74,3 +74,13 @@ spec:
                     secretKeyRef:
                       name: QOODISH_API_DB_USER
                       key: latest
+                - name: AR_ENCRYPTION_PRIMARY_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: QOODISH_API_AR_ENCRYPTION_PRIMARY_KEY
+                      key: latest
+                - name: AR_ENCRYPTION_KEY_DERIVATION_SALT
+                  valueFrom:
+                    secretKeyRef:
+                      name: QOODISH_API_AR_ENCRYPTION_KEY_DERIVATION_SALT
+                      key: latest


### PR DESCRIPTION
# Summary

Encrypt the journey trail column (`journeys.encoded_path`) with ActiveRecord Encryption so it is stored as ciphertext. The application decrypts transparently, so the API response is unchanged.

# Motivation

The trail records a user's continuous movement, which can reveal home location and daily routines — more sensitive than the discrete pinned spots already stored. As plaintext, anyone with read access to the database or a BigQuery export could see raw routes. The feature is released but not yet open, so no rows have accumulated and this is the point of lowest migration cost.

# Changes

- Add `encrypts :encoded_path` to `Journey`. Non-deterministic encryption is used because the column is never queried by value.
- Supply encryption keys from ENV (`AR_ENCRYPTION_PRIMARY_KEY`, `AR_ENCRYPTION_KEY_DERIVATION_SALT`) with `support_unencrypted_data = false`, matching the existing Secret Manager injection used for other secrets rather than depending on credentials.
- Wire the two keys via `secretKeyRef` in the Cloud Run api and runner manifests for both dev and prod.
- In the test environment, use fixed non-secret keys and `encrypt_fixtures = true` so fixtures load as ciphertext.

# Testing

The journey model and controller tests pass, verifying fixture encryption, transparent decryption, and an unchanged API round-trip. A direct database check confirms `encoded_path` is stored as the encrypted envelope rather than plaintext.

🤖 Generated with [Claude Code](https://claude.ai/code)