### PR TITLE
fix: re-key legacy invited notifications

### DIFF
--- a/db/migrate/20260724000000_migrate_legacy_notification_keys.rb
+++ b/db/migrate/20260724000000_migrate_legacy_notification_keys.rb
@@ -1,0 +1,17 @@
+class MigrateLegacyNotificationKeys < ActiveRecord::Migration[7.2]
+  # Old map invitations created notifications with key 'invited'. The coauthor
+  # permission redesign replaced that flow with coauthorships and switched the
+  # key to 'coauthor_invited', but existing notification rows kept the old key
+  # and no longer resolve. Re-key them so they render as coauthor invitations.
+  def up
+    execute <<~SQL.squish
+      UPDATE notifications SET key = 'coauthor_invited' WHERE key = 'invited'
+    SQL
+  end
+
+  def down
+    # Irreversible: after this runs, migrated 'invited' rows are
+    # indistinguishable from notifications created as 'coauthor_invited'.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Background

While investigating notifications rendering as `undefined` in the notifications list.

The web client builds each notification message with `dictionary[\`${key} ${notifiable.type}\`]`. The combinations the current backend produces — `key` (`coauthor_invited` / `liked` / `comment`) × notifiable type (Map / Review / Comment / Chapter) — all exist in the dictionary, so they normally resolve.

However, the commit that removed follows/invites (`chore!: drop follows and invites tables`) took `'followed'` and `'invited'` out of `KEYS` and deleted the matching branches in `Notification#click_action`, but **the existing notification rows (`key = 'invited'` / `'followed'`) were left untouched — their keys were never migrated**. As a result those legacy notifications no longer map to any current dictionary entry and render as `undefined`.

## Changes

Old map invitations (`key = 'invited'`) are semantically the same as the coauthor invitations (`key = 'coauthor_invited'`) introduced by the coauthor permission redesign, and their notifiable is a Map as well. This adds a data migration that re-keys those rows to `'coauthor_invited'` so they render as coauthor invitations.

```sql
UPDATE notifications SET key = 'coauthor_invited' WHERE key = 'invited'
```

## Out of scope

Notifications with `key = 'followed'` have no equivalent in the current scheme: following was removed entirely (following a map became a bookmark, which does not notify, and user following was dropped). Since there is no meaningful key to migrate them to, this PR leaves them unchanged and relies on the web client's fallback message.

## Notes

- Data-only migration; it does not change the schema.
- `down` is irreversible: once applied, migrated `'invited'` rows are indistinguishable from notifications created as `'coauthor_invited'`.

🤖 Generated with [Claude Code](https://claude.ai/code)