### PR TITLE
fix: hide notifications left by retired features

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,6 +5,7 @@ class NotificationsController < ApplicationController
     @notifications =
       current_user
       .notifications
+      .renderable
       .recent
       .includes({ notifier: :images }, :notifiable)
       .reject do |notification|

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -30,6 +30,13 @@ class Notification < ApplicationRecord
       .limit(10)
   }
 
+  # Rows created before a feature was retired can carry keys outside KEYS
+  # ('followed', 'invited'); they reference concepts and data that no longer
+  # exist, so they are kept but never served.
+  scope :renderable, lambda {
+    where(key: KEYS)
+  }
+
   def click_action
     case key
     when 'coauthor_invited'


### PR DESCRIPTION
## Background

Some notifications render as `undefined` in the notifications list.

The web client builds a notification's message from `key` + `notifiable.type`. Removing follows and invites (`chore!: drop follows and invites tables`) took `'followed'` and `'invited'` out of `Notification::KEYS`, but the notification rows created under those keys were left in place. The index kept serving them, so the client received retired keys it has no message for and showed `undefined`.

## Design decision

Neither retired key has anything current to stand for:

- `'followed'`: bookmarking, which replaced following, is defined as a private, reader-side act and is deliberately silent, so no bookmark notification exists to map it onto.
- `'invited'`: the invites table was dropped with all its rows, so these notifications announce invitations that no longer exist as data.

Both are treated the same way — as remnants of features that no longer exist: kept in the database, never served.

## Changes

- `Notification.renderable` scope (`where(key: KEYS)`), applied in the index before `recent`, so retired rows are filtered in SQL ahead of the 10-item limit and cannot crowd out renderable notifications.
- The Ruby-side `reject` keeps only the pre-existing orphaned `notifier` / `notifiable` guard, which cannot be a simple WHERE due to the polymorphic associations.

## Notes

- No notification data is rewritten or deleted.
- The bookmark-notification experiment previously on this branch (bookmark callbacks, the `'bookmarked'` key, the push-setting column and migration) is fully reverted; all other files match master.

🤖 Generated with [Claude Code](https://claude.ai/code)