### PR TITLE
feat: add GeoJSON map features to chapters

### DIFF
--- a/app/controllers/maps/chapters_controller.rb
+++ b/app/controllers/maps/chapters_controller.rb
@@ -14,6 +14,7 @@ module Maps
     def chapter_params
       permitted = params.permit(:title)
       permitted[:content] = params[:content].permit!.to_h if params[:content].is_a?(ActionController::Parameters)
+      permitted[:map_features] = params[:map_features].permit!.to_h if params[:map_features].is_a?(ActionController::Parameters)
       permitted
     end
   end

--- a/app/controllers/me/chapters_controller.rb
+++ b/app/controllers/me/chapters_controller.rb
@@ -32,6 +32,7 @@ module Me
     def chapter_params
       permitted = params.permit(:title, :status, image_ids: [])
       permitted[:content] = params[:content].permit!.to_h if params[:content].is_a?(ActionController::Parameters)
+      permitted[:map_features] = params[:map_features].permit!.to_h if params[:map_features].is_a?(ActionController::Parameters)
       permitted
     end
   end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 MAX_CHAPTER_CONTENT_BYTESIZE = 1.megabyte
+MAX_CHAPTER_MAP_FEATURES_BYTESIZE = 100.kilobytes
 CHAPTER_FEED_PER_PAGE = 12
 
 class Chapter < ApplicationRecord
+  EMPTY_FEATURE_COLLECTION = { 'type' => 'FeatureCollection', 'features' => [] }.freeze
+
+  # Styling keys from the simplestyle spec (marker-color, marker-symbol) are
+  # deliberately absent until there is UI to set them; unknown keys pass so
+  # documents imported from other GeoJSON tools survive a round trip.
+  FEATURE_TEXT_PROPERTIES = %w[title description].freeze
+
+  attribute :map_features, default: -> { EMPTY_FEATURE_COLLECTION.deep_dup }
+
   belongs_to :user
   belongs_to :map, optional: true
   belongs_to :journey, optional: true
@@ -34,6 +44,7 @@ class Chapter < ApplicationRecord
             }
   validates :images, length: { maximum: 1 }
   validate :content_must_be_lexical_document
+  validate :map_features_must_be_geojson_features
   validate :journey_must_match_author_and_map
 
   scope :referenceable_by, lambda { |user|
@@ -68,6 +79,10 @@ class Chapter < ApplicationRecord
   }
 
   def content=(value)
+    super(value.is_a?(Hash) ? value.deep_stringify_keys : value)
+  end
+
+  def map_features=(value)
     super(value.is_a?(Hash) ? value.deep_stringify_keys : value)
   end
 
@@ -106,5 +121,51 @@ class Chapter < ApplicationRecord
     return if journey.user_id == user_id && journey.map_id == map_id
 
     errors.add(:journey_id, I18n.t('messages.api.chapter_journey_mismatch'))
+  end
+
+  def map_features_must_be_geojson_features
+    unless feature_collection?(map_features)
+      errors.add(:map_features, I18n.t('messages.api.chapter_map_features_invalid'))
+      return
+    end
+
+    return if map_features.to_json.bytesize <= MAX_CHAPTER_MAP_FEATURES_BYTESIZE
+
+    errors.add(:map_features, I18n.t('messages.api.chapter_map_features_exceed'))
+  end
+
+  def feature_collection?(document)
+    document.is_a?(Hash) &&
+      document['type'] == 'FeatureCollection' &&
+      document['features'].is_a?(Array) &&
+      document['features'].all? { |feature| point_feature?(feature) }
+  end
+
+  # Point is the only geometry served to readers so far; widening this check
+  # per geometry type is how LineString and Polygon get introduced.
+  def point_feature?(feature)
+    feature.is_a?(Hash) &&
+      feature['type'] == 'Feature' &&
+      feature_properties?(feature['properties']) &&
+      feature['geometry'].is_a?(Hash) &&
+      feature['geometry']['type'] == 'Point' &&
+      point_coordinates?(feature['geometry']['coordinates'])
+  end
+
+  def feature_properties?(properties)
+    return true if properties.nil?
+
+    properties.is_a?(Hash) &&
+      FEATURE_TEXT_PROPERTIES.all? do |key|
+        properties[key].nil? || properties[key].is_a?(String)
+      end
+  end
+
+  def point_coordinates?(coordinates)
+    coordinates.is_a?(Array) &&
+      coordinates.length == 2 &&
+      coordinates.all? { |value| value.is_a?(Numeric) } &&
+      coordinates[0].between?(-180, 180) &&
+      coordinates[1].between?(-90, 90)
   end
 end

--- a/app/views/partials/_chapter.jbuilder
+++ b/app/views/partials/_chapter.jbuilder
@@ -4,6 +4,7 @@ json.journey_id chapter.journey_id
 json.title chapter.title
 json.status chapter.status
 json.content chapter.content
+json.map_features chapter.map_features
 json.image chapter.image_variants
 json.image_url chapter.image_url
 json.author do

--- a/app/views/partials/guest/_chapter.jbuilder
+++ b/app/views/partials/guest/_chapter.jbuilder
@@ -4,6 +4,7 @@ json.journey_id chapter.journey_id
 json.title chapter.title
 json.status chapter.status
 json.content chapter.content
+json.map_features chapter.map_features
 json.image chapter.image_variants
 json.image_url chapter.image_url
 json.author do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,8 @@ en:
       chapter_title_exceed: "Chapter title is too long. (Max: 100)"
       chapter_content_invalid: Chapter content is not a valid document.
       chapter_content_exceed: Chapter content is too large.
+      chapter_map_features_invalid: Chapter map features are not a valid GeoJSON FeatureCollection.
+      chapter_map_features_exceed: Chapter map features are too large.
       chapter_journey_mismatch: The journey does not belong to the author or the map of the chapter.
       duplicate_chapter_for_journey: A chapter has already been created for this journey.
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -49,6 +49,8 @@ ja:
       chapter_title_exceed: "チャプターのタイトルが長すぎます。(最大: 100 文字)"
       chapter_content_invalid: チャプターの本文の形式が正しくありません。
       chapter_content_exceed: チャプターの本文が大きすぎます。
+      chapter_map_features_invalid: チャプターの地図データの形式が正しくありません。
+      chapter_map_features_exceed: チャプターの地図データが大きすぎます。
       chapter_journey_mismatch: 指定された旅はチャプターの著者またはマップに属していません。
       duplicate_chapter_for_journey: この旅のチャプターは既に作成されています。
 

--- a/db/migrate/20260724170000_add_map_features_to_chapters.rb
+++ b/db/migrate/20260724170000_add_map_features_to_chapters.rb
@@ -1,0 +1,5 @@
+class AddMapFeaturesToChapters < ActiveRecord::Migration[7.2]
+  def change
+    add_column :chapters, :map_features, :json, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_23_114052) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_24_170000) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "map_id", null: false
     t.bigint "user_id", null: false
@@ -30,6 +30,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_23_114052) do
     t.json "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "map_features", null: false
     t.index ["journey_id"], name: "index_chapters_on_journey_id", unique: true
     t.index ["map_id"], name: "index_chapters_on_map_id"
     t.index ["user_id", "status"], name: "index_chapters_on_user_id_and_status"

--- a/test/fixtures/chapters.yml
+++ b/test/fixtures/chapters.yml
@@ -19,6 +19,9 @@ my_draft:
           name: This is a name
           latitude: 35.681382
           longitude: 139.766084
+  map_features:
+    type: FeatureCollection
+    features: []
 
 my_published:
   user: me
@@ -41,6 +44,17 @@ my_published:
           name: This is a name
           latitude: 35.681382
           longitude: 139.766084
+  map_features:
+    type: FeatureCollection
+    features:
+      - type: Feature
+        geometry:
+          type: Point
+          coordinates:
+            - 139.766084
+            - 35.681382
+        properties:
+          title: This is a name
 
 you_draft:
   user: you
@@ -52,6 +66,9 @@ you_draft:
       type: root
       version: 1
       children: []
+  map_features:
+    type: FeatureCollection
+    features: []
 
 you_published:
   user: you
@@ -69,6 +86,9 @@ you_published:
           name: This is a name
           latitude: 35.681382
           longitude: 139.766084
+  map_features:
+    type: FeatureCollection
+    features: []
 
 you_private_published_unfollowing:
   user: you
@@ -80,6 +100,9 @@ you_private_published_unfollowing:
       type: root
       version: 1
       children: []
+  map_features:
+    type: FeatureCollection
+    features: []
 
 you_private_published_following:
   user: you
@@ -92,3 +115,6 @@ you_private_published_following:
       type: root
       version: 1
       children: []
+  map_features:
+    type: FeatureCollection
+    features: []

--- a/test/models/chapter_test.rb
+++ b/test/models/chapter_test.rb
@@ -31,6 +31,150 @@ class ChapterTest < ActiveSupport::TestCase
     assert_not chapter.valid?
   end
 
+  test 'map features default to an empty feature collection' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT
+    )
+
+    assert chapter.valid?
+    assert_equal Chapter::EMPTY_FEATURE_COLLECTION, chapter.map_features
+  end
+
+  test 'valid chapter with point map features' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT,
+      map_features: {
+        'type' => 'FeatureCollection',
+        'features' => [
+          {
+            'type' => 'Feature',
+            'geometry' => { 'type' => 'Point', 'coordinates' => [138.86, 35.1] },
+            'properties' => { 'title' => 'Numazu', 'description' => 'Tsukemen' }
+          }
+        ]
+      }
+    )
+
+    assert chapter.valid?
+  end
+
+  test 'map features keep unknown properties' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT,
+      map_features: {
+        'type' => 'FeatureCollection',
+        'features' => [
+          {
+            'type' => 'Feature',
+            'geometry' => { 'type' => 'Point', 'coordinates' => [138.86, 35.1] },
+            'properties' => { 'marker-color' => '#ff0000' }
+          }
+        ]
+      }
+    )
+
+    assert chapter.valid?
+  end
+
+  test 'map features title must be a string' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT,
+      map_features: {
+        'type' => 'FeatureCollection',
+        'features' => [
+          {
+            'type' => 'Feature',
+            'geometry' => { 'type' => 'Point', 'coordinates' => [138.86, 35.1] },
+            'properties' => { 'title' => 42 }
+          }
+        ]
+      }
+    )
+
+    assert_not chapter.valid?
+  end
+
+  test 'map features cannot be null' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT,
+      map_features: nil
+    )
+
+    assert_not chapter.valid?
+  end
+
+  test 'map features must be a feature collection' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT,
+      map_features: { 'foo' => 'bar' }
+    )
+
+    assert_not chapter.valid?
+  end
+
+  test 'map features geometry must be a point' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT,
+      map_features: {
+        'type' => 'FeatureCollection',
+        'features' => [
+          {
+            'type' => 'Feature',
+            'geometry' => {
+              'type' => 'LineString',
+              'coordinates' => [[138.86, 35.1], [138.87, 35.11]]
+            },
+            'properties' => {}
+          }
+        ]
+      }
+    )
+
+    assert_not chapter.valid?
+  end
+
+  test 'map features coordinates must be in range' do
+    chapter = Chapter.new(
+      user: users(:you),
+      map: maps(:public_unfollowing),
+      title: 'A walk',
+      content: LEXICAL_DOCUMENT,
+      map_features: {
+        'type' => 'FeatureCollection',
+        'features' => [
+          {
+            'type' => 'Feature',
+            'geometry' => { 'type' => 'Point', 'coordinates' => [35.1, 138.86] },
+            'properties' => {}
+          }
+        ]
+      }
+    )
+
+    assert_not chapter.valid?
+  end
+
   test 'journey of another user cannot be recorded' do
     chapter = Chapter.new(
       user: users(:you),


### PR DESCRIPTION
## Summary

Adds a `map_features` column to chapters that holds a GeoJSON FeatureCollection.

The chapter read page used to render its map from the author's journey checkins, but journeys are private location history served only under `/me`, so readers and guests never saw the map. Giving the chapter its own map data decouples it from the journey: the journey stays behind `/me` endpoints, while the chapter owns a map the author can edit freely after it is seeded from the checkins.

## Changes

- Add a NOT NULL `chapters.map_features` JSON column. New records get an empty FeatureCollection from a model-level default, so no reader has to branch on nil
- Validate the column on `Chapter` as a GeoJSON FeatureCollection
  - Only the `Point` geometry is accepted for now, with longitude/latitude range checks; LineString / Polygon can be introduced by widening the per-type validation
  - Feature properties follow the [simplestyle spec](https://github.com/mapbox/simplestyle-spec): `title` and `description` are validated as strings, and unknown keys pass so documents imported from other GeoJSON tools survive a round trip. Styling keys (`marker-color`, `marker-symbol`) are left out until there is UI to set them
  - The whole document is capped at 100KB
- Accept `map_features` on create (`Maps::ChaptersController`) and update (`Me::ChaptersController`), permitted the same way as `content` and replaced wholesale
- Serialize `map_features` in the `_chapter` / `guest/_chapter` partials
- Add model tests and give the fixtures a map document

## Notes

- Chapters are not released yet, so the column is added NOT NULL directly. The migration expects no existing rows; delete any left over in a development database before running it
- Seeding (journey checkins → `Feature<Point>`) happens on the frontend, in the same place that already generates the chapter content (qoodish-web PR #1075)
- `encoded_path` (the trail), checkin timestamps, and notes still never leave `/me`
- `description` has no editing UI yet; the key is settled now so adding one later needs no data migration

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chapters now support map features using GeoJSON point data.
  - Map features are included in chapter API responses for signed-in and guest views.
  - Chapters without map features default to an empty feature collection.

- **Bug Fixes**
  - Invalid map data is rejected with clear errors, including unsupported formats, coordinates, or oversized content.
  - Map feature data is normalized consistently when submitted through the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->