### PR TITLE
feat: list the chapters written from a map

### DIFF
--- a/app/controllers/guest/maps/chapters_controller.rb
+++ b/app/controllers/guest/maps/chapters_controller.rb
@@ -1,0 +1,11 @@
+class Guest::Maps::ChaptersController < ApplicationController
+  def index
+    map = Map.public_open.find_by!(id: params[:map_id])
+
+    @chapters = Chapter
+                .public_open
+                .where(map_id: map.id)
+                .preload(:map, :images, user: %i[images journal])
+                .order(created_at: :desc)
+  end
+end

--- a/app/controllers/maps/chapters_controller.rb
+++ b/app/controllers/maps/chapters_controller.rb
@@ -2,6 +2,16 @@ module Maps
   class ChaptersController < ApplicationController
     before_action :authenticate_user!
 
+    def index
+      map = current_user.referenceable_maps.find_by!(id: params[:map_id])
+
+      @chapters = Chapter
+                  .referenceable_by(current_user)
+                  .where(map_id: map.id)
+                  .preload(:map, :votes, :images, user: %i[images journal])
+                  .order(created_at: :desc)
+    end
+
     def create
       map = current_user.referenceable_maps.find_by!(id: params[:map_id])
       journey = current_user.journeys.find_by!(id: params[:journey_id]) if params[:journey_id].present?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,11 +43,11 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    current_user.reviews.preload(:images, :votes).load
-    current_user.maps.preload(:images, :coauthorships, :bookmarks, :coauthorship_invitations, :votes,
-                              reviews: [:images, :votes]).load
+    current_user.reviews.preload(:images, :votes, :notifications).load
+    current_user.maps.preload(:images, :coauthorships, :bookmarks, :coauthorship_invitations, :votes, :notifications,
+                              reviews: %i[images votes notifications]).load
     current_user.journeys.preload(:milestones, checkins: :images).load
-    current_user.chapters.preload(:votes, :images).load
+    current_user.chapters.preload(:votes, :images, :notifications).load
     current_user.destroy!
   end
 

--- a/app/jobs/bloadcast_web_push_job.rb
+++ b/app/jobs/bloadcast_web_push_job.rb
@@ -1,7 +1,0 @@
-class BloadcastWebPushJob < ApplicationJob
-  queue_as :default
-
-  def perform(notification)
-    notification.bloadcast_web_push
-  end
-end

--- a/app/jobs/broadcast_web_push_job.rb
+++ b/app/jobs/broadcast_web_push_job.rb
@@ -1,0 +1,7 @@
+class BroadcastWebPushJob < ApplicationJob
+  queue_as :default
+
+  def perform(notification)
+    notification.broadcast_web_push
+  end
+end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -20,6 +20,7 @@ class Chapter < ApplicationRecord
   has_many :votes, as: :votable, dependent: :destroy
   has_many :voters, through: :votes, source: :voter, source_type: User.name
   has_many :images, as: :imageable, dependent: :destroy
+  has_many :notifications, as: :notifiable, dependent: :destroy
 
   enum :status, { draft: 'draft', published: 'published' }, validate: true
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,7 @@ class Comment < ApplicationRecord
   belongs_to :user
   has_many :votes, as: :votable, dependent: :destroy
   has_many :voters, through: :votes, source: :voter, source_type: User.name
+  has_many :notifications, as: :notifiable, dependent: :destroy
 
   validates :body,
             presence: true,

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -5,7 +5,7 @@ class Map < ApplicationRecord
 
   belongs_to :user
   has_many :reviews, dependent: :destroy
-  has_many :notifications, as: :notifiable
+  has_many :notifications, as: :notifiable, dependent: :destroy
   has_many :coauthorships, dependent: :destroy
   has_many :coauthors, through: :coauthorships, source: :user
   has_many :bookmarks, dependent: :destroy

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -23,7 +23,7 @@ class Notification < ApplicationRecord
               in: KEYS
             }
 
-  after_create_commit :bloadcast_web_push_later
+  after_create_commit :broadcast_web_push_later
 
   scope :recent, lambda {
     order(created_at: :desc)
@@ -61,7 +61,7 @@ class Notification < ApplicationRecord
     end
   end
 
-  def bloadcast_web_push
+  def broadcast_web_push
     google_auth = GoogleAuth.new
     access_token = google_auth.fetch_access_token(FCM_SCOPE)
 
@@ -115,9 +115,9 @@ class Notification < ApplicationRecord
 
   private
 
-  def bloadcast_web_push_later
+  def broadcast_web_push_later
     return unless allowed_web_push?
 
-    BloadcastWebPushJob.perform_later(self)
+    BroadcastWebPushJob.perform_later(self)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -7,7 +7,7 @@ class Review < ApplicationRecord
   belongs_to :user
   belongs_to :map
   has_many :images, as: :imageable, dependent: :destroy
-  has_many :notifications, as: :notifiable
+  has_many :notifications, as: :notifiable, dependent: :destroy
   has_many :comments, as: :commentable
   has_many :votes, as: :votable, dependent: :destroy
   has_many :voters, through: :votes, source: :voter, source_type: User.name

--- a/app/views/guest/maps/chapters/index.jbuilder
+++ b/app/views/guest/maps/chapters/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @chapters, partial: 'partials/guest/chapter', as: :chapter

--- a/app/views/maps/chapters/index.jbuilder
+++ b/app/views/maps/chapters/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @chapters, partial: 'partials/chapter', as: :chapter

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       resource :bookmark, only: %i[create destroy]
       resources :coauthorship_invitations, only: [:create]
       resources :journeys, only: [:create]
-      resources :chapters, only: [:create]
+      resources :chapters, only: %i[index create]
     end
   end
   resources :coauthorship_invitations, only: [:index] do
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
           end
         end
         resources :coauthors, only: [:index]
+        resources :chapters, only: [:index]
       end
     end
     resources :reviews, only: %i[index show]

--- a/test/controllers/guest/maps/chapters_controller_test.rb
+++ b/test/controllers/guest/maps/chapters_controller_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class Guest::Maps::ChaptersControllerTest < ActionDispatch::IntegrationTest
+  test 'index should return published chapters written from a public map' do
+    get "/guest/maps/#{maps(:public_one).id}/chapters"
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    ids = res.map { |chapter| chapter['id'] }
+
+    assert_equal [chapters(:you_published_on_my_map).id, chapters(:my_published).id], ids
+    assert_not_includes ids, chapters(:my_draft).id
+    assert_not_includes ids, chapters(:you_draft_on_my_map).id
+  end
+
+  test 'index should not expose whether a chapter is editable' do
+    get "/guest/maps/#{maps(:public_one).id}/chapters"
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert res.none? { |chapter| chapter.key?('editable') }
+  end
+
+  test 'index on a private map should raise not found error' do
+    get "/guest/maps/#{maps(:private).id}/chapters"
+
+    assert_response :not_found
+  end
+end

--- a/test/controllers/journals_controller_test.rb
+++ b/test/controllers/journals_controller_test.rb
@@ -14,7 +14,7 @@ class JournalsControllerTest < ActionDispatch::IntegrationTest
     assert_equal journals(:you_journal).id, res['id']
     assert_not res['editable']
     assert res['bookmarking']
-    assert_equal 3, res['chapters_count']
+    assert_equal 4, res['chapters_count']
   end
 
   test 'update own journal should be success' do

--- a/test/controllers/maps/chapters_controller_test.rb
+++ b/test/controllers/maps/chapters_controller_test.rb
@@ -9,6 +9,52 @@ class Maps::ChaptersControllerTest < ActionDispatch::IntegrationTest
     }
   }.freeze
 
+  test 'index should return published chapters written from the map' do
+    stub_google_auth(users(:me)) do
+      get "/maps/#{maps(:public_one).id}/chapters",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+    ids = res.map { |chapter| chapter['id'] }
+
+    assert_equal [chapters(:you_published_on_my_map).id, chapters(:my_published).id], ids
+    assert_not_includes ids, chapters(:my_draft).id
+    assert_not_includes ids, chapters(:you_draft_on_my_map).id
+    assert_not_includes ids, chapters(:you_published).id
+  end
+
+  test 'index on a private map as a coauthor should be success' do
+    stub_google_auth(users(:me)) do
+      get "/maps/#{maps(:private_following).id}/chapters",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal [chapters(:you_private_published_following).id],
+                 res.map { |chapter| chapter['id'] }
+  end
+
+  test 'index on an unreferenceable private map should raise not found error' do
+    stub_google_auth(users(:me)) do
+      get "/maps/#{maps(:private_unfollowing).id}/chapters",
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'index without authentication should raise unauthorized error' do
+    get "/maps/#{maps(:public_one).id}/chapters"
+
+    assert_response :unauthorized
+  end
+
   test 'create a chapter recording a journey should be success' do
     assert_difference 'Chapter.count', 1 do
       stub_google_auth(users(:me)) do

--- a/test/fixtures/chapters.yml
+++ b/test/fixtures/chapters.yml
@@ -90,6 +90,35 @@ you_published:
     type: FeatureCollection
     features: []
 
+you_draft_on_my_map:
+  user: you
+  map: public_one
+  title: Your draft chapter on my map
+  status: draft
+  content:
+    root:
+      type: root
+      version: 1
+      children: []
+  map_features:
+    type: FeatureCollection
+    features: []
+
+you_published_on_my_map:
+  user: you
+  map: public_one
+  title: Your published chapter on my map
+  status: published
+  created_at: 2026-06-20 12:00:00
+  content:
+    root:
+      type: root
+      version: 1
+      children: []
+  map_features:
+    type: FeatureCollection
+    features: []
+
 you_private_published_unfollowing:
   user: you
   map: private_unfollowing

--- a/test/jobs/broadcast_web_push_job_test.rb
+++ b/test/jobs/broadcast_web_push_job_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class BloadcastWebPushJobTest < ActiveJob::TestCase
+class BroadcastWebPushJobTest < ActiveJob::TestCase
   # test "the truth" do
   #   assert true
   # end

--- a/test/models/chapter_test.rb
+++ b/test/models/chapter_test.rb
@@ -254,4 +254,17 @@ class ChapterTest < ActiveSupport::TestCase
     assert_not_includes public_chapters, chapters(:my_draft)
   end
 
+  test 'destroying a chapter destroys its notifications' do
+    chapter = chapters(:you_published_on_my_map)
+    Notification.create!(
+      notifiable: chapter,
+      notifier: users(:me),
+      recipient: chapter.user,
+      key: 'liked'
+    )
+
+    assert_difference 'Notification.count', -1 do
+      chapter.destroy!
+    end
+  end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -4,7 +4,7 @@ class NotificationTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
   test 'web push on create' do
-    assert_enqueued_with(job: BloadcastWebPushJob) do
+    assert_enqueued_with(job: BroadcastWebPushJob) do
       Notification.create!(
         notifiable: reviews(:public_you_one),
         notifier: users(:me),


### PR DESCRIPTION
# Summary

Adds the map side of story circulation: a map now serves the published chapters written from it.

Covers the backend half of yusuke-suzuki/qoodish-web#1080. The frontend half is in yusuke-suzuki/qoodish-web.

# Motivation

A chapter belongs to the map it came from, but nothing carried that relationship back. The map had no endpoint listing the chapters written from it, so a reader arriving at a map could not reach the stories it produced, and the author could not see what their map led people to write.

# Changes

## Listing the chapters of a map

- `GET /maps/:map_id/chapters` returns the published chapters on a map the caller can reference, newest first. An unreferenceable map raises not found rather than returning an empty list, matching `Maps::ChaptersController#create`.
- `GET /guest/maps/:map_id/chapters` serves the same listing on public maps, so the stories are visible before signing in.
- Published only. A draft is author-only and may never be finished, so it is not part of what a map has produced. This settles the open question in yusuke-suzuki/qoodish-web#1080 about whether the viewer's own drafts belong here.
- Both actions reuse the existing chapter partials rather than introducing a summary shape, keeping one serialization of a chapter across the profile listing and this one.

## Not in this PR: notifying the map author

yusuke-suzuki/qoodish-web#1079 asks for the map's author to be told when a chapter is published from their map. An earlier revision of this PR carried it, and it is removed.

The notification would have been created but never pushed. Push delivery is gated on `recipient.push_notification[key]`, which forces the preference column and the notification key to be the same string, and the two are read where different words are wanted: `published` is meaningless as a column, while `chapter_published` names the object twice in the copy key that reads `liked chapter` and `coauthor_invited map`. Adding a column would have made one of them wrong; adding the notification without one would have left a key that reaches the list and stops.

#564 reworks that mechanism and decides which notifications are worth sending at all. The notification lands there, once there is somewhere sound to put it, rather than becoming another thing that has to be unpicked.

## Fixes found in review

- Destroying a review, map, chapter, or comment left its notifications behind, pointing at a record that no longer exists. The rows were never served — `NotificationsController#index` drops any whose notifiable has gone — but they accumulated for good, and `Comment` had no association to hang the behaviour on at all. All four now declare `dependent: :destroy`, matching the `votes` and `images` associations beside them, and `UsersController#destroy` preloads the notifications along with the associations it already loads before deleting an account.
- `BloadcastWebPushJob` and `Notification#bloadcast_web_push` are spelled `Broadcast` / `broadcast`. The misspelling was what every caller had to type. Active Job runs on the default in-process adapter with no persistent queue, so no enqueued payload carries the old class name across a deploy.

# Testing

`bin/rails test` — 267 runs, 608 assertions, 0 failures.

One error remains: `NotificationTest#test_web_push_on_create` fails in `GoogleAuth#make_credentials` because the sandbox has no Google service account credentials. It fails identically on `master` before these changes, and CI supplies the credentials.

`JournalsControllerTest#test_show_a_journal_of_another_user_should_be_success` asserts a chapter count derived from fixtures. The new fixture adds one published chapter authored by `you`, so the expected count moves from 3 to 4.

# Release procedure

No migration, and the API stays backward compatible with the current `qoodish-web`. Release this change, then the corresponding `qoodish-web` change, which depends on `GET /maps/:map_id/chapters`.

🤖 Generated with [Claude Code](https://claude.ai/code)



## Summary by CodeRabbit

* **New Features**
  * Added chapter listings for public maps and authenticated users with appropriate access controls.

* **Bug Fixes**
  * Corrected web push background processing.
  * Ensured notifications are removed when related content is deleted.

* **Tests**
  * Added coverage for public, private, and unauthorized chapter listing scenarios.