### PR TITLE
feat: rework web push preference storage

### DIFF
--- a/app/controllers/users/push_notifications_controller.rb
+++ b/app/controllers/users/push_notifications_controller.rb
@@ -3,16 +3,14 @@ module Users
     before_action :authenticate_user!
 
     def update
-      push_notification = PushNotification.find_or_initialize_by(user: current_user)
-
-      push_notification.update!(push_notification_params)
+      current_user.update_web_push_preferences!(push_notification_params)
     end
 
     private
 
     def push_notification_params
       params
-        .permit(:coauthor_invited, :liked, :comment)
+        .permit(:coauthor_invited, :liked, :comment, :published)
         .to_h
     end
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,7 +3,8 @@ class Notification < ApplicationRecord
   belongs_to :notifier, polymorphic: true
   belongs_to :recipient, polymorphic: true
 
-  KEYS = %w[coauthor_invited liked comment].freeze
+  KEYS = %w[coauthor_invited liked comment published].freeze
+
   FCM_SCOPE = 'https://www.googleapis.com/auth/firebase.messaging'.freeze
 
   validates :notifiable_type,
@@ -56,6 +57,8 @@ class Notification < ApplicationRecord
       else
         ''
       end
+    when 'published'
+      notifiable_type == Chapter.name ? "/chapters/#{notifiable.id}" : ''
     else
       ''
     end
@@ -106,11 +109,7 @@ class Notification < ApplicationRecord
   end
 
   def allowed_web_push?
-    if recipient.push_notification.blank?
-      false
-    else
-      recipient.push_notification[key]
-    end
+    recipient.web_push_preferences[key]
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,19 @@ class User < ApplicationRecord
       .limit(20)
   }
 
+  def web_push_preferences
+    UserPreference.effective_web_push(
+      preferences.last&.web_push || legacy_web_push
+    )
+  end
+
+  # Composes the previous effective values with the keys it was sent,
+  # so a client built before a preference existed cannot reset it by
+  # omission.
+  def update_web_push_preferences!(changes)
+    preferences.create!(web_push: web_push_preferences.merge(changes))
+  end
+
   def image_url
     images.first&.url.to_s
   end
@@ -142,6 +155,20 @@ class User < ApplicationRecord
   end
 
   private
+
+  # Transitional read-through to push_notifications, which is unwritten
+  # from this release on; removed together with the table once the
+  # backfill has carried the remaining rows over.
+  def legacy_web_push
+    row = push_notification
+    return nil if row.blank?
+
+    {
+      'coauthor_invited' => row.coauthor_invited,
+      'liked' => row.liked,
+      'comment' => row.comment
+    }
+  end
 
   def delete_id_platform_account
     id_platform.delete_account(uid)

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -6,7 +6,7 @@ class UserPreference < ApplicationRecord
     'coauthor_invited' => true,
     'liked' => true,
     'comment' => true,
-    'chapter_published' => true
+    'published' => true
   }.freeze
 
   # Rows are never updated: each save appends a full snapshot of the

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -11,9 +11,13 @@ class Vote < ApplicationRecord
               in: [User.name]
             }
 
-  after_create :create_notification
+  after_create :create_notification, unless: :on_yourself?
 
   private
+
+  def on_yourself?
+    voter_id == votable.user_id
+  end
 
   def create_notification
     Notification.create!(

--- a/app/views/partials/_user.jbuilder
+++ b/app/views/partials/_user.jbuilder
@@ -8,7 +8,7 @@ json.maps_count user.maps.count
 json.bookmarked_maps_count user.bookmark_count
 json.reviews_count user.reviews.count
 json.push_notification do
-  json.coauthor_invited user.push_notification ? user.push_notification.coauthor_invited : false
-  json.liked user.push_notification ? user.push_notification.liked : false
-  json.comment user.push_notification ? user.push_notification.comment : false
+  user.web_push_preferences.each do |preference, enabled|
+    json.set! preference, enabled
+  end
 end

--- a/lib/tasks/backfill_user_preferences.rb
+++ b/lib/tasks/backfill_user_preferences.rb
@@ -1,0 +1,25 @@
+# bin/rails runner lib/tasks/backfill_user_preferences.rb
+#
+# Carries the explicit choices stored in push_notifications into
+# user_preferences as one full snapshot per user. Reads fall through
+# to push_notifications until this has run, so there is no urgency;
+# run it any time before the release that removes that fallback and
+# drops the table.
+# Safe to re-run: users that already have a snapshot are skipped.
+
+backfilled = 0
+
+PushNotification.includes(:user).find_each do |row|
+  next if row.user.preferences.exists?
+
+  row.user.preferences.create!(
+    web_push: {
+      'coauthor_invited' => row.coauthor_invited,
+      'liked' => row.liked,
+      'comment' => row.comment
+    }
+  )
+  backfilled += 1
+end
+
+Rails.logger.info("Backfill complete: #{backfilled} snapshots")

--- a/test/controllers/users/push_notifications_controller_test.rb
+++ b/test/controllers/users/push_notifications_controller_test.rb
@@ -1,7 +1,80 @@
 require 'test_helper'
 
 class Users::PushNotificationsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'update stores the preferences' do
+    stub_google_auth(users(:me)) do
+      put "/users/#{users(:me).uid}/push_notification",
+          params: {
+            coauthor_invited: false,
+            liked: false,
+            comment: false,
+            published: false
+          },
+          as: :json,
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    preferences = users(:me).reload.web_push_preferences
+
+    assert_not preferences['coauthor_invited']
+    assert_not preferences['liked']
+    assert_not preferences['comment']
+    assert_not preferences['published']
+  end
+
+  test 'update keeps the preferences it was not sent' do
+    users(:me).update_web_push_preferences!('published' => false)
+
+    stub_google_auth(users(:me)) do
+      put "/users/#{users(:me).uid}/push_notification",
+          params: { liked: false },
+          as: :json,
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    preferences = users(:me).reload.web_push_preferences
+
+    assert_not preferences['liked']
+    assert_not preferences['published']
+    assert preferences['comment']
+  end
+
+  test 'update responds with the effective preferences' do
+    stub_google_auth(users(:me)) do
+      put "/users/#{users(:me).uid}/push_notification",
+          params: { liked: false },
+          as: :json,
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :success
+
+    res = JSON.parse(@response.body)
+
+    assert_equal false, res['push_notification']['liked']
+    assert_equal true, res['push_notification']['published']
+  end
+
+  test 'update rejects a value that is not a boolean' do
+    stub_google_auth(users(:me)) do
+      put "/users/#{users(:me).uid}/push_notification",
+          params: { liked: 'no' },
+          headers: { 'Authorization': 'Bearer dummytoken' }
+    end
+
+    assert_response :unprocessable_content
+    assert users(:me).web_push_preferences['liked']
+  end
+
+  test 'update without a token should be unauthorized' do
+    put "/users/#{users(:me).uid}/push_notification",
+        params: { liked: false },
+        as: :json
+
+    assert_response :unauthorized
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -11,7 +11,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     res = JSON.parse(@response.body)
 
     assert_equal res['uid'], users(:me).uid
-    assert res['push_notification'].present?
+    assert_equal %w[coauthor_invited liked comment published],
+                 res['push_notification'].keys
+    assert res['push_notification'].values.all?
   end
 
   test 'request to your profile should be success' do

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -21,4 +21,47 @@ class NotificationTest < ActiveSupport::TestCase
 
     perform_enqueued_jobs
   end
+
+  test 'web push without stored preferences by default' do
+    assert_empty users(:you).preferences
+
+    assert_enqueued_with(job: BroadcastWebPushJob) do
+      Notification.create!(
+        notifiable: reviews(:public_you_one),
+        notifier: users(:me),
+        recipient: users(:you),
+        key: 'liked'
+      )
+    end
+  end
+
+  test 'no web push when the preference is disabled' do
+    users(:you).update_web_push_preferences!('liked' => false)
+
+    assert_no_enqueued_jobs do
+      Notification.create!(
+        notifiable: reviews(:public_you_one),
+        notifier: users(:me),
+        recipient: users(:you),
+        key: 'liked'
+      )
+    end
+  end
+
+  test 'every key is gated by a preference of the same name' do
+    assert_empty Notification::KEYS - UserPreference::WEB_PUSH_DEFAULTS.keys
+  end
+
+  test 'no web push when the published preference is disabled' do
+    users(:me).update_web_push_preferences!('published' => false)
+
+    assert_no_enqueued_jobs do
+      Notification.create!(
+        notifiable: chapters(:you_published_on_my_map),
+        notifier: users(:you),
+        recipient: users(:me),
+        key: 'published'
+      )
+    end
+  end
 end

--- a/test/models/user_preference_test.rb
+++ b/test/models/user_preference_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class UserPreferenceTest < ActiveSupport::TestCase
+  test 'a user without snapshots reads as the defaults' do
+    assert_empty users(:me).preferences
+    assert_equal UserPreference::WEB_PUSH_DEFAULTS,
+                 users(:me).web_push_preferences
+  end
+
+  test 'saving stores a full snapshot' do
+    users(:me).update_web_push_preferences!('liked' => false)
+
+    assert_equal UserPreference::WEB_PUSH_DEFAULTS.merge('liked' => false),
+                 users(:me).preferences.last.web_push
+  end
+
+  test 'a save without a key keeps the previous choice' do
+    users(:me).update_web_push_preferences!('published' => false)
+    users(:me).update_web_push_preferences!('liked' => false)
+
+    preferences = users(:me).web_push_preferences
+
+    assert_equal false, preferences['liked']
+    assert_equal false, preferences['published']
+  end
+
+  test 'the latest snapshot wins' do
+    users(:me).update_web_push_preferences!('liked' => false)
+    users(:me).update_web_push_preferences!('liked' => true)
+
+    assert_equal true, users(:me).web_push_preferences['liked']
+  end
+
+  test 'a stored key outside the known preferences is dropped' do
+    users(:me).preferences.create!(web_push: { 'followed' => true })
+
+    assert_not_includes users(:me).web_push_preferences.keys, 'followed'
+  end
+
+  test 'a snapshot that does not hold booleans is invalid' do
+    ['no', 'false', 1, [true], [], nil].each do |value|
+      assert_raises(ActiveRecord::RecordInvalid, "accepted #{value.inspect}") do
+        users(:me).preferences.create!(web_push: { 'liked' => value })
+      end
+    end
+  end
+
+  test 'a snapshot that is not an object is invalid' do
+    ['garbage', [1, 2], nil].each do |value|
+      assert_raises(ActiveRecord::RecordInvalid, "accepted #{value.inspect}") do
+        users(:me).preferences.create!(web_push: value)
+      end
+    end
+  end
+
+  test 'a symbol keyed snapshot keeps its choices' do
+    users(:me).preferences.create!(web_push: { liked: false })
+
+    assert_equal false, users(:me).web_push_preferences['liked']
+  end
+
+  test 'a symbol keyed save overrides the previous choice' do
+    users(:me).update_web_push_preferences!(liked: false)
+
+    assert_equal false, users(:me).web_push_preferences['liked']
+  end
+
+  test 'a user without snapshots reads the legacy row' do
+    users(:me).push_notification.update!(liked: false)
+
+    assert_equal false, users(:me).web_push_preferences['liked']
+  end
+
+  test 'the first save carries the legacy choices forward' do
+    users(:me).push_notification.update!(liked: false)
+
+    users(:me).update_web_push_preferences!('comment' => false)
+
+    snapshot = users(:me).preferences.last.web_push
+
+    assert_equal false, snapshot['liked']
+    assert_equal false, snapshot['comment']
+  end
+
+  test 'a snapshot takes precedence over the legacy row' do
+    users(:me).push_notification.update!(liked: false)
+    users(:me).preferences.create!(web_push: UserPreference::WEB_PUSH_DEFAULTS)
+
+    assert_equal true, users(:me).web_push_preferences['liked']
+  end
+end

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class VoteTest < ActiveSupport::TestCase
+  test 'liking the content of another user notifies them' do
+    assert_difference 'Notification.count', 1 do
+      users(:me).liked!(chapters(:you_published))
+    end
+
+    notification = Notification.last
+
+    assert_equal 'liked', notification.key
+    assert_equal users(:you), notification.recipient
+  end
+
+  test 'liking your own content notifies nobody' do
+    assert_difference 'Vote.count' => 1, 'Notification.count' => 0 do
+      users(:me).liked!(chapters(:my_published))
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Reworks how web push preferences are stored and read: preferences move from per-key boolean columns to append-only snapshots in `user_preferences`, with the new `published` preference served and accepted. Closes #564. Second step of the sequence #567 → this → yusuke-suzuki/qoodish-web#1083 → #568; notification creation itself switches on in #568.

# Motivation

Push delivery was gated on `recipient.push_notification[key]`, one boolean column per notification key. Every new notification kind cost a migration, the schema still carries the columns of features that no longer exist (`followed`, `invited`), and users who had never saved the settings card had no row at all, so they received nothing. The chapter-published notification (yusuke-suzuki/qoodish-web#1079) was blocked on all three.

# Changes

## Preference storage

- `user_preferences` (model and table added unreferenced by #567) is append-only: each save inserts a full snapshot of the user's choices as a `web_push` JSON value, and the latest row is the current state. Nothing updates in place, so concurrent saves cannot tear each other, and there is no singleton row whose first creation could race — the concerns raised in review are removed structurally rather than locked around. Snapshots also keep the current state readable in plain SQL, and the history is a time series of full states.
- A save composes the previous effective values with the keys it was sent, so a client built before a preference existed cannot reset it by omission.
- A user with no snapshots reads through to their legacy `push_notifications` row, so explicit opt-outs keep working with no backfill deadline; the first save carries them into a snapshot. A user with neither reads as the defaults, and all four defaults are on: users who enabled push at the device level now receive pushes without ever saving the settings card. A key absent from a stored snapshot (added after that snapshot was taken) also falls back to its default.
- A preference is named after the notification key it gates, so `allowed_web_push?` is a plain lookup with nothing to translate. A test asserts every `Notification::KEYS` entry has a preference of the same name — without it, adding a key and forgetting the preference would silently disable its push. The `published` key and its `click_action` ship here but stay inert until #568 creates the first notification.
- Values are validated, not coerced: a snapshot must be an object holding only booleans, so a stray `"no"` is a 422 rather than a silent opt-in. The `push_notification` object in the profile response keeps its flat shape and now serves four effective values; the current frontend reads three of them and stays compatible.

## Self-like fix

- Liking your own content notified yourself. `Vote` now applies the same `on_yourself?` guard `Comment` already has.

# Testing

`bin/rails test` — 290 runs, 665 assertions, 0 failures.

One error remains: `NotificationTest#test_web_push_on_create` fails in `GoogleAuth#make_credentials` because the sandbox has no Google service account credentials. It fails identically on `master`, and CI supplies the credentials.

# Release procedure

Full sequence, each step released before the next:

1. #567 — the model and table, unreferenced (run `db:migrate` via `qoodish-runner`; the running version ignores the table, so timing is free). Done, released as v3.7.0.
2. This PR — writes to `push_notifications` stop; reads fall through to it for users without snapshots. No runner step of its own.
3. yusuke-suzuki/qoodish-web#1083 — the settings toggle and notification copy.
4. #568 — chapter-published notification creation switches on.
5. Later, in this order: run `lib/tasks/backfill_user_preferences.rb` (materializes snapshots for users who still only have a legacy row; no urgency while the fallback exists), verify `push_notifications` has no row without a matching snapshot, ship a release removing the fallback and the `PushNotification` model, and only after that a release dropping the table — the two-release rule.

🤖 Generated with [Claude Code](https://claude.ai/code)



## Summary by CodeRabbit

* **New Features**
  * Added support for managing web push preferences, including chapter publication notifications.
  * User profiles now show the full set of notification preference toggles.
  * Updates preserve previously saved preferences for settings not included in the request.
* **Bug Fixes**
  * Push notifications now respect each user's saved preferences.
  * Users no longer receive notifications when they interact with their own content.
  * Published chapter notifications now link to the correct chapter when applicable.
* **Data Migration**
  * Existing notification settings are backfilled into the new preferences storage.