### PR TITLE
feat: add the user_preferences model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,10 @@ class User < ApplicationRecord
   has_many :owned_images, class_name: 'Image', dependent: :destroy
   has_many :images, as: :imageable, dependent: :destroy
   has_one :push_notification, dependent: :destroy
+  has_many :preferences,
+           class_name: 'UserPreference',
+           inverse_of: :user,
+           dependent: :destroy
 
   validates :uid,
             presence: true,

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -1,0 +1,38 @@
+class UserPreference < ApplicationRecord
+  # A key absent from a stored snapshot falls back to its default, so a
+  # notification introduced later reaches users without waiting for them
+  # to revisit the settings screen.
+  WEB_PUSH_DEFAULTS = {
+    'coauthor_invited' => true,
+    'liked' => true,
+    'comment' => true,
+    'chapter_published' => true
+  }.freeze
+
+  # Rows are never updated: each save appends a full snapshot of the
+  # user's choices, and the latest row is the current state.
+  #
+  # optional with a user_id presence validation: the default belongs_to
+  # validation reads the association, and Bullet then flags the owner
+  # as a potential N+1 for the rest of the request. NOT NULL and the
+  # foreign key keep presence enforced in the database.
+  belongs_to :user, inverse_of: :preferences, optional: true
+
+  validates :user_id, presence: true
+  validate :web_push_must_hold_booleans
+
+  def self.effective_web_push(stored)
+    WEB_PUSH_DEFAULTS.merge(
+      stored.to_h.slice(*WEB_PUSH_DEFAULTS.keys)
+    )
+  end
+
+  private
+
+  def web_push_must_hold_booleans
+    return if web_push.is_a?(Hash) &&
+              web_push.values.all? { |value| [true, false].include?(value) }
+
+    errors.add(:web_push, :invalid)
+  end
+end

--- a/db/migrate/20260726144020_create_user_preferences.rb
+++ b/db/migrate/20260726144020_create_user_preferences.rb
@@ -1,0 +1,10 @@
+class CreateUserPreferences < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_preferences do |t|
+      t.references :user, null: false, foreign_key: true
+      t.json :web_push, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_24_170000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_26_144020) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "map_id", null: false
     t.bigint "user_id", null: false
@@ -223,6 +223,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_24_170000) do
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
+  create_table "user_preferences", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.json "web_push", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_preferences_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -274,4 +282,5 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_24_170000) do
   add_foreign_key "push_notifications", "users"
   add_foreign_key "reviews", "maps"
   add_foreign_key "reviews", "users"
+  add_foreign_key "user_preferences", "users"
 end


### PR DESCRIPTION
# Summary

Adds the `user_preferences` model — table, class and the `User` association as one unit, the way `rails g model` produces them — with nothing calling it yet. First step of the release sequence for the web push preference rework (#564); the code that reads and writes it follows in #566.

# Motivation

Merging a release deploys and shifts traffic automatically, so shipping this migration together with the code that reads the table would leave a window between the traffic shift and the runner's `db:migrate` in which every profile render — including sign-in — fails on a missing table. Landing the unreferenced model one release ahead removes that window: the class and its associations load without touching the database, so the migration can run at any point after this release goes out.

# Changes

- `user_preferences`: `user_id` (indexed, foreign key) and a `web_push` JSON column.
- `UserPreference`: append-only snapshot semantics documented on the model, the per-key defaults, `effective_web_push` (defaults merged under a stored snapshot, with unknown keys dropped), and a validation that a snapshot is an object holding only booleans.
- `User has_many :preferences`: the other half of the pair, so `inverse_of` resolves within this release.

Rows are appended by #566; nothing in this release instantiates the class, so its behaviour is covered by the tests arriving there.

# Notes

`web_push` is a plain JSON hash guarded by a model validation rather than a typed value object. Rails 8 covers this case directly with `has_json`, which enforces a flat schema of booleans, integers and strings with per-key defaults — exactly the shape here — and would replace the constant, the merge helper and the validation with one declaration. This repository is on Rails 7.2, so the implementation stays deliberately small: the intent is to migrate to `has_json` with the Rails 8 upgrade rather than to build a lasting abstraction now.

Rails' `:boolean` type is not used for the same reason it would be wrong here in any version: it casts every value it does not recognise to `true`, so `"no"` would be stored as an opt-in. The validation reads the raw values instead.

Key normalization is left to Rails: a JSON attribute stringifies hash keys on assignment, so a symbol-keyed snapshot round-trips without help.

# Release procedure

Merge and release this first, run `db:migrate` via `qoodish-runner`, then proceed with #566.

🤖 Generated with [Claude Code](https://claude.ai/code)



## Summary by CodeRabbit

* **New Features**
  * Added user-specific notification preferences with persistent storage.
  * Introduced structured web push notification settings stored as required data.
  * Added validation to ensure preferences are tied to a user and that each web push option is a valid boolean value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing user notification preferences, including web push settings.
  * Added default notification settings when individual preferences are not specified.
  * Added validation to ensure notification settings use valid boolean values.
  * Users can now have multiple preference snapshots associated with their account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->