### PR TITLE
feat: notify the map author of a new chapter

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -24,6 +24,8 @@ class Chapter < ApplicationRecord
 
   enum :status, { draft: 'draft', published: 'published' }, validate: true
 
+  after_update :notify_map_author, if: :just_published?
+
   validates :title,
             presence: {
               message: I18n.t('messages.api.chapter_title_required')
@@ -105,6 +107,22 @@ class Chapter < ApplicationRecord
   end
 
   private
+
+  def just_published?
+    saved_change_to_status == %w[draft published]
+  end
+
+  def notify_map_author
+    return if map.blank? || map.user_id == user_id
+    return if notifications.exists?(key: 'published')
+
+    Notification.create!(
+      notifiable: self,
+      notifier: user,
+      recipient: map.user,
+      key: 'published'
+    )
+  end
 
   def content_must_be_lexical_document
     unless content.is_a?(Hash) && content['root'].is_a?(Hash)

--- a/test/models/chapter_test.rb
+++ b/test/models/chapter_test.rb
@@ -267,4 +267,67 @@ class ChapterTest < ActiveSupport::TestCase
       chapter.destroy!
     end
   end
+
+  test 'publishing a chapter notifies the map author' do
+    chapter = chapters(:you_draft_on_my_map)
+
+    assert_difference 'Notification.count', 1 do
+      chapter.update!(status: 'published')
+    end
+
+    notification = Notification.last
+
+    assert_equal 'published', notification.key
+    assert_equal chapter, notification.notifiable
+    assert_equal users(:you), notification.notifier
+    assert_equal users(:me), notification.recipient
+    assert_equal "/chapters/#{chapter.id}", notification.click_action
+  end
+
+  test 'publishing a chapter on own map notifies nobody' do
+    assert_no_difference 'Notification.count' do
+      chapters(:my_draft).update!(status: 'published')
+    end
+  end
+
+  test 'publishing again after reverting to draft notifies only once' do
+    chapter = chapters(:you_draft_on_my_map)
+
+    chapter.update!(status: 'published')
+    chapter.update!(status: 'draft')
+
+    assert_no_difference 'Notification.count' do
+      chapter.update!(status: 'published')
+    end
+  end
+
+  test 'editing a published chapter notifies nobody' do
+    assert_no_difference 'Notification.count' do
+      chapters(:you_published_on_my_map).update!(title: 'A new title')
+    end
+  end
+
+  test 'a failed notification rolls the publication back' do
+    chapter = chapters(:you_draft_on_my_map)
+    failing_create = lambda { |*|
+      raise ActiveRecord::RecordNotSaved.new('failed', Notification.new)
+    }
+
+    Notification.stub :create!, failing_create do
+      assert_raises(ActiveRecord::RecordNotSaved) do
+        chapter.update!(status: 'published')
+      end
+    end
+
+    assert_predicate chapter.reload, :draft?
+  end
+
+  test 'publishing a chapter whose map is gone notifies nobody' do
+    chapter = chapters(:you_draft_on_my_map)
+    chapter.map.destroy!
+
+    assert_no_difference 'Notification.count' do
+      chapter.reload.update!(status: 'published')
+    end
+  end
 end


### PR DESCRIPTION
# Summary

Enables the chapter-published notification: a map's author is notified when a chapter on their map moves from draft to published. Closes yusuke-suzuki/qoodish-web#1079. Final step of the sequence #567 → #566 → yusuke-suzuki/qoodish-web#1083 → this.

# Motivation

A map's author had no way to learn that their map led someone to write. The notification key, its `click_action`, the `published` preference and the frontend copy all ship in the earlier steps; this one starts creating the notification, last in the sequence so the copy is live before the first row exists — otherwise the notification row would render the notifier's name followed by nothing.

# Changes

- `Chapter#notify_map_author` on the draft to published transition, inside the publishing transaction so a failed notification rolls the publication back. Creation does not notify, since a draft is author-only. Skipped when the chapter's author owns the map, when the chapter was already published once (a revert to draft and republish stays silent), and when the map is gone.

# Testing

`bin/rails test` — 296 runs, 682 assertions, 0 failures. One pre-existing environment error (`NotificationTest#test_web_push_on_create`, Google service account credentials absent in the sandbox; CI supplies them).

# Release procedure

Release only after yusuke-suzuki/qoodish-web#1083 is live.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map authors now receive a notification when someone else publishes a chapter on their map.
  * Notifications include a link to the published chapter and are not duplicated for repeat edits.

* **Bug Fixes**
  * Publishing chapters on your own map, or chapters without an associated map, no longer creates unnecessary notifications.
  * Failed notification delivery prevents the chapter from being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->