### PR TITLE
docs: record how a release is triggered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,9 @@ These rules cover database migrations, releases, and backward compatibility. Fol
 ### Release Flow
 
 - Releases are driven by `release-please`. Merging the release PR into `master` tags a new version, which builds the image and deploys the new application revision with traffic shifted to it.
+- A release PR is only opened when `master` has gained a releasable unit since the last release, which means a commit prefixed `feat`, `fix`, or `deps`. Merging a batch of `refactor`, `chore`, or `docs` commits produces no release; they wait for the next feature or fix to carry them.
+- When a change must land in a release of its own — a migration that cannot share one with the code it depends on, for example — do not rely on a later feature to trigger it. Put `Release-As: x.y.z` in the footer of that change's own commit, keeping the prefix that describes the change.
+- Do not use an empty commit to carry `Release-As:`. Rebase merge drops a commit with no changes, so the PR merges while `master` gains nothing and the footer never arrives.
 
 ### Dropping Columns
 


### PR DESCRIPTION
# Summary

Writes the release-trigger rules into `CLAUDE.md`, and carries `Release-As: 3.9.1` so the two refactors sitting on `master` finally ship. Replaces #574, which merged without landing a commit.

# Motivation

Two things bit this sequence, both easy to hit again.

Release-please only opens a release pull request when `master` has gained a **releasable unit** since the last release — a commit prefixed `feat`, `fix`, or `deps`. #572 and #573 are both `refactor`, so merging them produced no release. Choosing those prefixes was the mistake: each carried an ordering constraint that only holds if it actually releases, and instead they were left waiting for an unrelated feature to carry them.

#574 tried to fix that with the empty commit the release-please README suggests. It failed silently: rebase merge drops a commit with no changes, so the pull request merged while `master` gained nothing and the footer never reached release-please. `a9cf486` is not an ancestor of `master`. That recipe assumes a direct push to the default branch, not a pull request.

Both rules are worth having in writing before the table-drop pull request is opened, since that one needs a release of its own.

# Changes

- `CLAUDE.md` gains three lines under **Release Flow**: what counts as a releasable unit, that `Release-As:` belongs on the commit of the change that needs its own release, and that an empty commit cannot carry it.

The commit itself carries `Release-As: 3.9.1`. The version is a patch: #572 and #573 are internal, leaving the API contract, the routes, and the profile response untouched.

# Testing

No code changes. The confirmation is behavioural — release-please should open a release pull request for 3.9.1 once this merges. If it does not, the footer on a `docs` commit is not enough on its own, and the fallback is to merge a footer-carrying commit with a merge commit rather than a rebase, so an empty commit survives.

# Release procedure

Merge this, then merge the release pull request it produces. That release needs `db:migrate` via `qoodish-runner`, for the foreign-key migration in #573.

The table drop follows in a later release and must not share one with #573. Its own commit will carry a `Release-As:` footer, per the rule this PR writes down.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRLFdcj3ts6tamzwHWHkhe)_