### PR TITLE
fix: notify only once when a like is repeated

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -20,6 +20,8 @@ class Vote < ApplicationRecord
   end
 
   def create_notification
+    return if votable.notifications.exists?(notifier: voter, key: 'liked')
+
     Notification.create!(
       notifiable: votable,
       notifier: voter,

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -12,6 +12,18 @@ class VoteTest < ActiveSupport::TestCase
     assert_equal users(:you), notification.recipient
   end
 
+  test 'liking again after unliking notifies only once' do
+    assert_difference 'Notification.count', 1 do
+      users(:me).liked!(chapters(:you_published))
+    end
+
+    users(:me).unliked!(chapters(:you_published))
+
+    assert_no_difference 'Notification.count' do
+      users(:me).liked!(chapters(:you_published))
+    end
+  end
+
   test 'liking your own content notifies nobody' do
     assert_difference 'Vote.count' => 1, 'Notification.count' => 0 do
       users(:me).liked!(chapters(:my_published))


### PR DESCRIPTION
# Summary

A like notifies its recipient once per reader and piece of content. Repeating like → unlike → like no longer produces a notification and a push each time.

# Motivation

`User#unliked!` destroys the vote and leaves the notification alone, so the next `liked!` on the same content runs the `after_create` callback again and creates a second notification with a second web push. Nothing bounds the repetition, so any reader can aim a stream of pushes at an author by toggling one button.

Found while reviewing the notification paths touched by #566 and #568. `Chapter#notify_map_author` already guards against re-publication in the same way; likes did not.

# Changes

- `Vote#create_notification` returns early when the content already carries a `liked` notification from the same voter.

The guard is per voter and per piece of content, so a like from a different reader still notifies, and the notification for the first like keeps its original timestamp rather than being renewed. Nothing removes a `liked` notification on its own: `notifications` is routed `only: %i[index update]`, and rows go only through the cascade when the notifiable is destroyed — at which point the votable is gone and there is nothing left to re-like.

# Testing

`bin/rails test` — 294 runs, 682 assertions, 0 failures.

The new test fails on `master` with `"Notification.count" didn't change by 0, but by 1`, confirming the defect before the guard is added.

One error remains: `NotificationTest#test_web_push_on_create` fails in `GoogleAuth#make_credentials` because the sandbox has no Google service account credentials. It fails identically on `master`, and CI supplies the credentials.

# Release procedure

No runner step for this change itself. Being a `fix`, it is a releasable unit, so merging it opens the release pull request that #572 and #573 have been waiting for.

That release carries the foreign-key migration from #573, so it does need `db:migrate` via `qoodish-runner`.

The pull request dropping the `push_notifications` table follows in a later release and must not share one with #573.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate “liked” notifications when content is liked again after being unliked.
  * Preserve the original “liked” notification instead of generating additional duplicates.
  * Added automated test coverage for the unlike-then-like notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->