### PR TITLE
refactor: drop the push_notifications table

### DIFF
--- a/db/migrate/20260728160209_drop_push_notifications.rb
+++ b/db/migrate/20260728160209_drop_push_notifications.rb
@@ -1,0 +1,15 @@
+class DropPushNotifications < ActiveRecord::Migration[7.2]
+  def change
+    drop_table :push_notifications do |t|
+      t.bigint :user_id, null: false
+      t.boolean :followed, default: false, null: false
+      t.boolean :invited, default: false, null: false
+      t.boolean :liked, default: false, null: false
+      t.boolean :comment, default: false, null: false
+      t.timestamps
+      t.boolean :coauthor_invited, default: false, null: false
+
+      t.index :user_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_28_065006) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_28_160209) do
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "map_id", null: false
     t.bigint "user_id", null: false
@@ -195,18 +195,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_28_065006) do
     t.index ["notifier_type", "notifier_id"], name: "index_notifications_on_notifier_type_and_notifier_id"
     t.index ["recipient_id", "recipient_type"], name: "index_notifications_on_recipient_id_and_recipient_type"
     t.index ["recipient_type", "recipient_id"], name: "index_notifications_on_recipient_type_and_recipient_id"
-  end
-
-  create_table "push_notifications", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.boolean "followed", default: false, null: false
-    t.boolean "invited", default: false, null: false
-    t.boolean "liked", default: false, null: false
-    t.boolean "comment", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "coauthor_invited", default: false, null: false
-    t.index ["user_id"], name: "index_push_notifications_on_user_id"
   end
 
   create_table "reviews", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|


### PR DESCRIPTION
# Summary

Drops `push_notifications`. Last step of the move to `user_preferences` that began with #567, closing out #564.

# Motivation

Nothing has referenced the table since v3.9.1, which removed the `PushNotification` model, the `has_one`, and the foreign key. The backfill carried its rows into `user_preferences` snapshots before that, so the schema is all that remains of the per-key boolean columns — including `followed` and `invited`, left behind by features that no longer exist.

Waiting for v3.9.1 to be live was the point of separating this from #573. The revision serving traffic during that release still cascaded into the table on account deletion; the one serving traffic during this release does not touch it at all.

# Changes

- `db/migrate/20260728160209_drop_push_notifications.rb` — `drop_table :push_notifications`, with the column definitions so the migration is reversible.

# Testing

`bin/rails test` — 294 runs, 682 assertions, 0 failures.

Rolling the migration back and diffing `db/schema.rb` against `master` produces no change, so the reverse definition reconstructs the table as it stood: same columns, defaults, timestamps, and index name.

One error remains: `NotificationTest#test_web_push_on_create` fails in `GoogleAuth#make_credentials` because the sandbox has no Google service account credentials. It fails identically on `master`, and CI supplies the credentials.

# Release procedure

Run `db:migrate` via `qoodish-runner` for this release.

`refactor` is not a releasable unit, so the commit carries `Release-As: 3.9.2` to open the release pull request on its own rather than waiting for an unrelated change to carry it. Merging must preserve the commit message: release-please reads `release-as` as a footer, which a rebase or merge commit keeps and a squash that rewrites the body would drop.

The drop is the point of no return for the legacy rows. They exist in `user_preferences` as snapshots, but not in their original form.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRLFdcj3ts6tamzwHWHkhe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the obsolete push notifications data structure from the application database.
  * Updated the database schema to reflect the removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->