### PR TITLE
refactor: strip carriage returns with normalizes

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,6 +5,8 @@ class Comment < ApplicationRecord
   has_many :voters, through: :votes, source: :voter, source_type: User.name
   has_many :notifications, as: :notifiable, dependent: :destroy
 
+  normalizes :body, with: ->(text) { text.delete("\r") }
+
   validates :body,
             presence: true,
             length: {

--- a/app/models/journey_checkin.rb
+++ b/app/models/journey_checkin.rb
@@ -11,7 +11,8 @@ class JourneyCheckin < ApplicationRecord
 
   delegate :user_id, to: :journey
 
-  before_validation :remove_carriage_return
+  normalizes :note, with: ->(text) { text.delete("\r") }
+
   before_validation :set_default_checked_in_at, on: :create
 
   validates :review_id,
@@ -32,10 +33,6 @@ class JourneyCheckin < ApplicationRecord
   validate :checked_in_at_must_be_within_journey_period, if: :checked_in_at_changed?
 
   private
-
-  def remove_carriage_return
-    note.delete!("\r") if note.present?
-  end
 
   def set_default_checked_in_at
     self.checked_in_at ||= Time.current

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -17,6 +17,8 @@ class Map < ApplicationRecord
   has_many :journeys, dependent: :nullify
   has_many :chapters, dependent: :nullify
 
+  normalizes :name, :description, with: ->(text) { text.delete("\r") }
+
   validates :name,
             presence: {
               message: I18n.t('messages.api.map_name_required')
@@ -46,7 +48,6 @@ class Map < ApplicationRecord
             }
   validates :images, length: { maximum: 1 }
 
-  before_validation :remove_carriage_return
   after_update :destroy_bookmarks_when_private, if: :saved_change_to_private?
 
   scope :public_open, lambda {
@@ -120,11 +121,6 @@ class Map < ApplicationRecord
   end
 
   private
-
-  def remove_carriage_return
-    name&.delete!("\r")
-    description&.delete!("\r")
-  end
 
   def destroy_bookmarks_when_private
     bookmarks.destroy_all if private?

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -14,7 +14,7 @@ class Review < ApplicationRecord
   has_many :milestones, dependent: :nullify
   has_many :journey_checkins, dependent: :nullify
 
-  before_validation :remove_carriage_return
+  normalizes :name, :comment, with: ->(text) { text.delete("\r") }
 
   validates :comment,
             presence: {
@@ -89,12 +89,5 @@ class Review < ApplicationRecord
 
   def lng
     longitude.to_f
-  end
-
-  private
-
-  def remove_carriage_return
-    name.delete!("\r") if name.present?
-    comment.delete!("\r") if comment.present?
   end
 end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -5,4 +5,13 @@ class CommentTest < ActiveSupport::TestCase
     comment = comments(:one)
     assert_equal comment.commentable.image_variants, comment.image_variants
   end
+
+  test 'body drops carriage returns on assignment' do
+    comment = reviews(:public_one).comments.create!(
+      user: users(:me),
+      body: "First\r\nline"
+    )
+
+    assert_equal "First\nline", comment.reload.body
+  end
 end

--- a/test/models/map_test.rb
+++ b/test/models/map_test.rb
@@ -40,6 +40,16 @@ class MapTest < ActiveSupport::TestCase
     assert_not_includes Map.related_to(users(:you)).pluck(:id), map.id
   end
 
+  test 'name and description drop carriage returns on assignment' do
+    map = users(:me).maps.create!(
+      name: "Kyoto\r\ntrip",
+      description: "First\r\nvisit"
+    )
+
+    assert_equal "Kyoto\ntrip", map.reload.name
+    assert_equal "First\nvisit", map.description
+  end
+
   test 'making a map private destroys its bookmarks' do
     map = maps(:public_one) # bookmarked by you (you_on_public_one)
 

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -14,4 +14,17 @@ class ReviewTest < ActiveSupport::TestCase
 
     assert_nil review.image_variants
   end
+
+  test 'name and comment drop carriage returns on assignment' do
+    review = maps(:public_one).reviews.create!(
+      user: users(:me),
+      name: "Cafe\r\nBonjour",
+      comment: "Nice\r\nplace",
+      latitude: 35.681382,
+      longitude: 139.766084
+    )
+
+    assert_equal "Cafe\nBonjour", review.reload.name
+    assert_equal "Nice\nplace", review.comment
+  end
 end


### PR DESCRIPTION
# Summary

Carriage-return handling moves from hand-written `before_validation` callbacks to `normalizes`, which Active Record has provided for this since Rails 7.1. `Comment#body`, which had no such handling at all, gains it, so every free-text attribute served to a reader is stored with LF alone.

# Motivation

The callbacks predate `normalizes` and reimplemented what the framework provides. Following the Rails 8.1 upgrade in #580, the standard API removes three near-identical private methods and puts the rule next to the attributes it applies to.

`Comment#body` was the gap. `Review`, `Map` and `JourneyCheckin` stripped carriage returns; comment bodies were stored exactly as submitted, so a body sent as CRLF kept its CRs. A client that splits the body on LF gets a stray CR at the end of every line.

# Changes

- `Map` normalizes `name` and `description`; `Review` normalizes `name` and `comment`; `JourneyCheckin` normalizes `note`. The `remove_carriage_return` callbacks and their private methods are gone.
- `Comment` normalizes `body`. This is new behavior rather than a refactor, so it is a separate `fix` commit.
- Model tests pin the behavior for `Map`, `Review` and `Comment`, none of which had coverage for it. `JourneyCheckin#note` was already covered by the check-ins controller test.

# Behavior

Normalization runs when an attribute is assigned rather than before validation. Active Record deliberately does not apply it to values loaded from the database, so a row already persisted with a carriage return keeps it until that attribute is assigned again. Every write path that accepts user input assigns the attribute, so the input sanitizing this was written for is unaffected. Backfilling existing rows would need a Rake task in `lib/tasks`; this pull request does not add one.

`Comment#body` is capped at 500 characters and used to count carriage returns toward that cap. The cap is now measured after they are removed, so a body containing CRs passes slightly more often. `Review#comment` carries the same cap and has always measured it this way, so the two now agree.

As a side effect of `normalizes`, finder values are normalized too: `Map.find_by(name: "a\rb")` queries for `ab`.

# Compatibility with qoodish-web

No API contract changes and no migrations. Newly written comment bodies arrive with LF only instead of CRLF; the JSON shape is unchanged and existing rows are untouched, so qoodish-web needs no corresponding change and no release ordering constraint exists.

# Testing

- `bin/rails test` against MySQL 8.0.46: 297 runs, 687 assertions, 0 failures, 1 error.
- The single error is `NotificationTest#test_web_push_on_create`, which needs Google Cloud service account credentials absent from the sandbox. It fails identically on the base commit.
- Newline handling was checked end to end for `Review#comment` — model assignment, the raw column, and the JSON response — for LF and CRLF input over both JSON and form-encoded requests. LF survives in every case; only CR is removed.
- RuboCop reports no offenses on the changed files. Note that `bin/rubocop` cannot run in this repository at all: the binstub passes `--config .rubocop.yml` and that file does not exist, which also breaks the `Style: Ruby` step in `config/ci.rb`. This is unrelated to the change and left as is.

# Release procedure

No runner step. The `fix` commit makes this a releasable unit, so merging opens the release pull request without a `Release-As:` footer.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013p6xvA2zWZG8toxGDWapFV)_



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text handling for journey check-ins, maps, and reviews by removing carriage-return characters from notes, names, descriptions, and comments.
  * Ensures Windows-style line breaks are consistently stored as standard newline characters.

* **Tests**
  * Added coverage confirming normalized text remains consistent after saving and reloading records.

