### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Summary
+
+<!-- Brief description (2-3 sentences) -->
+
+# Motivation
+
+<!-- Why are these changes needed? -->
+
+# Changes
+
+<!-- - Key changes (what, not how) -->
+
+# Testing
+
+<!-- How the changes were verified (e.g., `bin/rails test` results).
+If testing is not applicable, state why. -->
+
+<!-- Add a "Release procedure" section when the release has ordering
+constraints across versions or with qoodish-web -->


### PR DESCRIPTION
# Summary

Add a pull request template so PR descriptions start from the structure the existing PRs already follow.

# Motivation

Without a committed template, each PR author or tool has to supply the description skeleton itself. GitHub pre-fills the template from the default branch in its PR form, and PR-creating tooling can fill the committed file directly.

# Changes

- Add `.github/pull_request_template.md` with Summary / Motivation / Changes / Testing sections, and a comment calling for a Release procedure section when a release has ordering constraints

# Testing

Not applicable — no application code changes; the template only affects the GitHub PR form.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFoaBWyEVz7xfHNaEGDiA3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a standardized pull request template with sections for summary, motivation, changes, testing, and optional release procedures.
  * Included guidance for documenting version-ordering constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->